### PR TITLE
This commit namespaces all library targets with pasta_, as we observe…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2020 Trail of Bits, Inc., all rights reserved.
+
 cmake_minimum_required(VERSION 3.14.5)
 
 # Takes care of some vcpkg automation so that we can use VCPKG_ROOT
@@ -42,31 +43,35 @@ else()
     message(WARNING "Unsupported C++ compiler '${CMAKE_CXX_COMPILER_ID}'; build may not work right!")
 endif()
 
-# --------------------------------------------
-# `cxx_settings` for global build options ----
-# --------------------------------------------
-add_library(cxx_settings INTERFACE)
-target_include_directories(cxx_settings INTERFACE
+# --------------------------------------------------
+# `pasta_cxx_settings` for global build options ----
+# --------------------------------------------------
+add_library(pasta_cxx_settings INTERFACE)
+target_include_directories(pasta_cxx_settings INTERFACE
     "${CMAKE_CURRENT_LIST_DIR}/include"
 )
 
-target_compile_options(cxx_settings INTERFACE ${CXX_WARNING_OPTIONS})
+target_compile_options(pasta_cxx_settings INTERFACE ${CXX_WARNING_OPTIONS})
 
 if(WARNINGS_AS_ERRORS)
-    target_compile_options(cxx_settings INTERFACE ${CXX_WARNINGS_AS_ERRORS_OPTION})
+    target_compile_options(pasta_cxx_settings INTERFACE ${CXX_WARNINGS_AS_ERRORS_OPTION})
+endif()
+
+if(BOOTSTRAP_MACROS OR BOOTSTRAP_TYPES)
+    target_compile_definitions(pasta_cxx_settings PUBLIC -DPASTA_IN_BOOTSTRAP)
 endif()
 
 find_package(Filesystem REQUIRED COMPONENTS Final Experimental)
 if(Filesystem_FOUND)
     message(STATUS "Found filesystem: ${CXX_FILESYSTEM_HEADER}")
 endif()
-target_link_libraries(cxx_settings INTERFACE std::filesystem)
+target_link_libraries(pasta_cxx_settings INTERFACE std::filesystem)
 
 # --------------------------------------------
 # Python dependencies ------------------------
 # --------------------------------------------
 
-find_package(PythonInterp 3.7 REQUIRED)
+find_package(PythonInterp 3.8 REQUIRED)
 if("x${PYTHON_LIBRARIES}x" STREQUAL "xx")
     execute_process(
         COMMAND "${PYTHON_EXECUTABLE}" -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR'), end='')"
@@ -79,10 +84,10 @@ if("x${PYTHON_INCLUDE_DIRS}x" STREQUAL "xx")
         OUTPUT_VARIABLE PYTHON_INCLUDE_DIR)
     message(STATUS "Found PYTHON_INCLUDE_DIR: ${PYTHON_INCLUDE_DIR}")
 endif()
-find_package(PythonLibs 3.7 REQUIRED)
+find_package(PythonLibs 3.8 REQUIRED)
 
-add_library(thirdparty_python INTERFACE)
-target_include_directories(thirdparty_python INTERFACE
+add_library(pasta_thirdparty_python INTERFACE)
+target_include_directories(pasta_thirdparty_python INTERFACE
     ${PYTHON_INCLUDE_DIRS}
 )
 
@@ -92,7 +97,7 @@ target_include_directories(thirdparty_python INTERFACE
 
 find_package(LLVM CONFIG REQUIRED)
 find_package(Clang CONFIG REQUIRED)
-add_library(thirdparty_llvm INTERFACE)
+add_library(pasta_thirdparty_llvm INTERFACE)
 
 # These are out-of-order in `LLVM_AVAILABLE_LIBS` and should always be last.
 set(LLVM_LIBRARIES ${LLVM_AVAILABLE_LIBS})
@@ -100,7 +105,7 @@ list(REMOVE_ITEM LLVM_LIBRARIES LLVMCore LLVMSupport)
 list(REMOVE_DUPLICATES LLVM_LIBRARIES)
 list(APPEND LLVM_LIBRARIES LLVMCore LLVMSupport)
 
-target_link_libraries(thirdparty_llvm INTERFACE
+target_link_libraries(pasta_thirdparty_llvm INTERFACE
     ${LLVM_LIBRARIES}
 
     clangSema
@@ -118,13 +123,13 @@ target_link_libraries(thirdparty_llvm INTERFACE
     clangIndex
 )
 
-target_include_directories(thirdparty_llvm INTERFACE
+target_include_directories(pasta_thirdparty_llvm INTERFACE
     ${LLVM_INCLUDE_DIRS}
     ${CLANG_INCLUDE_DIRS}
 )
 
 # TODO(pag): Not sure if `Clang_DEFINITIONS` or `CLANG_DEFINITIONS`.
-target_compile_definitions(thirdparty_llvm INTERFACE
+target_compile_definitions(pasta_thirdparty_llvm INTERFACE
     ${LLVM_DEFINITIONS}
     ${Clang_DEFINITIONS}
 )
@@ -178,7 +183,7 @@ configure_file("${HOST_H_IN_FILE}" "${HOST_H_FILE}" @ONLY)
 # Main build targets -------------------------
 # --------------------------------------------
 
-add_library(util STATIC
+add_library(pasta_util STATIC
     "include/pasta/Util/ArgumentVector.h"
     "include/pasta/Util/Compiler.h"
     "include/pasta/Util/Error.h"
@@ -191,12 +196,12 @@ add_library(util STATIC
     "lib/Util/Init.cpp"
 )
 
-target_link_libraries(util PRIVATE
-    cxx_settings
-    thirdparty_llvm
+target_link_libraries(pasta_util PRIVATE
+    pasta_cxx_settings
+    pasta_thirdparty_llvm
 )
 
-add_library(compiler STATIC
+add_library(pasta_compiler STATIC
 
     "include/pasta/AST/AST.h"
     "include/pasta/AST/Decl.h"
@@ -225,22 +230,17 @@ add_library(compiler STATIC
     "lib/Compile/Run.cpp"
 )
 
-
-if(BOOTSTRAP_MACROS OR BOOTSTRAP_TYPES)
-    target_compile_definitions(compiler PUBLIC -DPASTA_IN_BOOTSTRAP)
-endif()
-
-target_include_directories(compiler PRIVATE
+target_include_directories(pasta_compiler PRIVATE
     "${CMAKE_CURRENT_BINARY_DIR}/lib/Compile"
 )
 
-target_link_libraries(compiler PRIVATE
-    cxx_settings
-    thirdparty_llvm
-    util
+target_link_libraries(pasta_compiler PRIVATE
+    pasta_cxx_settings
+    pasta_thirdparty_llvm
+    pasta_util
 )
 
-add_library(python_bindings STATIC
+add_library(pasta_python_bindings STATIC
     "include/pasta/Python/Bindings.h"
 
     "lib/Python/Bindings.cpp"
@@ -256,97 +256,49 @@ add_library(python_bindings STATIC
     "lib/Python/Pasta.cpp"
 )
 
-target_link_libraries(python_bindings PRIVATE
-    compiler
-    cxx_settings
-    thirdparty_llvm
-    thirdparty_python
-    util
+target_link_libraries(pasta_python_bindings PRIVATE
+    pasta_compiler
+    pasta_cxx_settings
+    pasta_thirdparty_llvm
+    pasta_thirdparty_python
+    pasta_util
 )
-
 
 # ---------------------------------------------------
 # Configure bootstrap header files with source paths.
 # ---------------------------------------------------
 
-set(PASTA_INCLUDE_SOURCE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include")
-set(PASTA_BINARY_PATH "${CMAKE_CURRENT_BINARY_DIR}")
-set(PASTA_VCPKG_INCLUDE_PATH "${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}/include")
-set(PASTA_BIN_BOOTSTRAP_MACROS_MACRO_GENERATOR_CPP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/bin/BootstrapMacros/MacroGenerator.cpp")
-set(PASTA_BIN_BOOTSTRAP_TYPES_GENERATED_H_PATH "${CMAKE_CURRENT_SOURCE_DIR}/bin/BootstrapTypes/Generated.h")
-set(PASTA_INCLUDE_AST_FORWARD_H_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/pasta/AST/Forward.h")
-set(PASTA_INCLUDE_AST_DECL_H_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/pasta/AST/Decl.h")
-set(PASTA_SRC_AST_DECL_CPP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/lib/AST/Decl.cpp")
-set(PASTA_INCLUDE_AST_TYPE_H_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/pasta/AST/Type.h")
-set(PASTA_SRC_AST_TYPE_CPP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/lib/AST/Type.cpp")
-set(PASTA_INCLUDE_AST_TYPE_H_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/pasta/AST/Stmt.h")
-set(PASTA_SRC_AST_TYPE_CPP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/lib/AST/Stmt.cpp")
-
-set(BOOTSTRAP_CONFIG_H_IN "${CMAKE_CURRENT_SOURCE_DIR}/BootstrapConfig.h.in")
-set(BOOTSTRAP_CONFIG_H "${CMAKE_CURRENT_BINARY_DIR}/BootstrapConfig.h")
-configure_file("${BOOTSTRAP_CONFIG_H_IN}" "${BOOTSTRAP_CONFIG_H}" @ONLY)
-
-# --------------------------------------------
-# Bootstrap build targets --------------------
-# --------------------------------------------
-
-add_library(bootstrap-config INTERFACE)
-add_dependencies(bootstrap-config "${BOOTSTRAP_CONFIG_H}")
-target_include_directories(bootstrap-config INTERFACE
-    "${CMAKE_CURRENT_BINARY_DIR}"
-)
-
-if(BOOTSTRAP_MACROS)
-    add_executable(bootstrap-macros
-        "bin/BootstrapMacros/MacroGenerator.h"
-        "bin/BootstrapMacros/MacroGenerator.cpp"
-        "bin/BootstrapMacros/Main.cpp"
-    )
+if(BOOTSTRAP_MACROS OR BOOTSTRAP_TYPES)
     
-    target_link_libraries(bootstrap-macros PRIVATE
-        cxx_settings
-        thirdparty_llvm
-        compiler
-        bootstrap-config
+    set(PASTA_INCLUDE_SOURCE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include")
+    set(PASTA_BINARY_PATH "${CMAKE_CURRENT_BINARY_DIR}")
+    set(PASTA_VCPKG_INCLUDE_PATH "${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}/include")
+    set(PASTA_BIN_BOOTSTRAP_MACROS_MACRO_GENERATOR_CPP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/bin/BootstrapMacros/MacroGenerator.cpp")
+    set(PASTA_BIN_BOOTSTRAP_TYPES_GENERATED_H_PATH "${CMAKE_CURRENT_SOURCE_DIR}/bin/BootstrapTypes/Generated.h")
+    set(PASTA_INCLUDE_AST_FORWARD_H_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/pasta/AST/Forward.h")
+    set(PASTA_INCLUDE_AST_DECL_H_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/pasta/AST/Decl.h")
+    set(PASTA_SRC_AST_DECL_CPP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/lib/AST/Decl.cpp")
+    set(PASTA_INCLUDE_AST_TYPE_H_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/pasta/AST/Type.h")
+    set(PASTA_SRC_AST_TYPE_CPP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/lib/AST/Type.cpp")
+    set(PASTA_INCLUDE_AST_TYPE_H_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/pasta/AST/Stmt.h")
+    set(PASTA_SRC_AST_TYPE_CPP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/lib/AST/Stmt.cpp")
+    
+    set(BOOTSTRAP_CONFIG_H_IN "${CMAKE_CURRENT_SOURCE_DIR}/BootstrapConfig.h.in")
+    set(BOOTSTRAP_CONFIG_H "${CMAKE_CURRENT_BINARY_DIR}/BootstrapConfig.h")
+    configure_file("${BOOTSTRAP_CONFIG_H_IN}" "${BOOTSTRAP_CONFIG_H}" @ONLY)
+    
+    # --------------------------------------------
+    # Bootstrap build targets --------------------
+    # --------------------------------------------
+    
+    add_library(pasta_bootstrap_config INTERFACE)
+    add_dependencies(pasta_bootstrap_config "${BOOTSTRAP_CONFIG_H}")
+    target_include_directories(pasta_bootstrap_config INTERFACE
+        "${CMAKE_CURRENT_BINARY_DIR}"
     )
 
-    target_compile_definitions(bootstrap-macros PUBLIC -DPASTA_IN_BOOTSTRAP)
 endif()
 
-if(BOOTSTRAP_TYPES)
-    add_executable(bootstrap-types
-        "bin/BootstrapTypes/Generated.h"
-        "bin/BootstrapTypes/DefineDefaultMacros.h"
-        "bin/BootstrapTypes/UndefineDefaultMacros.h"
-        "bin/BootstrapTypes/Main.cpp"
-    
-        "bin/BootstrapTypes/DeclareCppMethods.cpp"
-        "bin/BootstrapTypes/DeclareEnums.cpp"
-        "bin/BootstrapTypes/DefineCppMethods.cpp"
-        "bin/BootstrapTypes/GenerateDeclCpp.cpp"
-        "bin/BootstrapTypes/GenerateDeclH.cpp"
-        "bin/BootstrapTypes/GenerateForwardH.cpp"
-        "bin/BootstrapTypes/Globals.cpp"
-        "bin/BootstrapTypes/Globals.h"
-        "bin/BootstrapTypes/MapDeclRetTypes.cpp"
-        "bin/BootstrapTypes/MapEnumRetTypes.cpp"
-        "bin/BootstrapTypes/Util.cpp"
-        "bin/BootstrapTypes/Util.h"
-    )
-    
-    target_link_libraries(bootstrap-types PRIVATE
-        cxx_settings
-        thirdparty_llvm
-        compiler
-        bootstrap-config
-    )
-
-    target_compile_definitions(bootstrap-types PUBLIC -DPASTA_IN_BOOTSTRAP)
-    
-    if(CMAKE_CXX_COMPILER_ID IN_LIST GNULIKE_COMPILER_LIST)
-        target_compile_options(bootstrap-types PUBLIC -O0 -g0)
-    endif()
-endif()
 
 # --------------------------------------------
 # Configure setup.py.in and __init__.py.in ---
@@ -360,7 +312,7 @@ set(INIT_PY "${CMAKE_CURRENT_BINARY_DIR}/pasta/__init__.py")
 
 set(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/timestamp")
 
-get_target_tree(DEPENDENT_LIBRARIES python_bindings)
+get_target_tree(DEPENDENT_LIBRARIES pasta_python_bindings)
 get_public_include_folders(INCLUDE_DIRS ${DEPENDENT_LIBRARIES})
 
 # Create a list of generator expressions that will find us the absolute paths
@@ -393,10 +345,13 @@ add_custom_command(
     COMMAND "${PYTHON_EXECUTABLE}" "${SETUP_PY}" build --force
     COMMAND "${CMAKE_COMMAND}" -E touch "${OUTPUT}"
     COMMENT "Building Pasta Python API"
-    DEPENDS python_bindings compiler
+    DEPENDS pasta_python_bindings pasta_compiler
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
-add_custom_target(build_python_ext ALL DEPENDS "${OUTPUT}")
+add_custom_target(pasta_build_python_ext ALL DEPENDS "${OUTPUT}")
 
 install(CODE "execute_process(COMMAND \"${PYTHON_EXECUTABLE}\" \"${SETUP_PY}\" install --force)")
+
+add_subdirectory(bin)
+

--- a/bin/BootstrapMacros/CMakeLists.txt
+++ b/bin/BootstrapMacros/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 Trail of Bits, Inc., all rights reserved.
+
+add_executable(bootstrap-macros
+    "MacroGenerator.h"
+    "MacroGenerator.cpp"
+    "Main.cpp"
+)
+
+target_link_libraries(bootstrap-macros PRIVATE
+    pasta_cxx_settings
+    pasta_thirdparty_llvm
+    pasta_compiler
+    pasta_bootstrap_config
+)

--- a/bin/BootstrapTypes/CMakeLists.txt
+++ b/bin/BootstrapTypes/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) 2020 Trail of Bits, Inc., all rights reserved.
+
+add_executable(bootstrap-types
+    "Generated.h"
+    "DefineDefaultMacros.h"
+    "UndefineDefaultMacros.h"
+    "Main.cpp"
+
+    "DeclareCppMethods.cpp"
+    "DeclareEnums.cpp"
+    "DefineCppMethods.cpp"
+    "GenerateDeclCpp.cpp"
+    "GenerateDeclH.cpp"
+    "GenerateForwardH.cpp"
+    "Globals.cpp"
+    "Globals.h"
+    "MapDeclRetTypes.cpp"
+    "MapEnumRetTypes.cpp"
+    "Util.cpp"
+    "Util.h"
+)
+
+target_link_libraries(bootstrap-types PRIVATE
+    pasta_cxx_settings
+    pasta_thirdparty_llvm
+    pasta_compiler
+    pasta_bootstrap_config
+)
+
+if(CMAKE_CXX_COMPILER_ID IN_LIST GNULIKE_COMPILER_LIST)
+    target_compile_options(bootstrap-types PUBLIC -O0 -g0)
+endif()

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) 2021 Trail of Bits, Inc., all rights reserved.
+
+if(BOOTSTRAP_MACROS)
+    add_subdirectory(BootstrapMacros)
+endif()
+
+if(BOOTSTRAP_TYPES)
+    add_subdirectory(BootstrapTypes)
+endif()
+
+add_subdirectory(DumpAST)

--- a/bin/DumpAST/CMakeLists.txt
+++ b/bin/DumpAST/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) 2021 Trail of Bits, Inc., all rights reserved.
+
+add_executable(dump-ast
+    "Main.cpp"
+)
+
+target_link_libraries(dump-ast PRIVATE
+    pasta_cxx_settings
+    pasta_thirdparty_llvm
+    pasta_compiler
+)

--- a/bin/DumpAST/Main.cpp
+++ b/bin/DumpAST/Main.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021 Trail of Bits, Inc.
+ */
+
+#include <pasta/AST/AST.h>
+#include <pasta/Compile/Command.h>
+#include <pasta/Compile/Compiler.h>
+#include <pasta/Compile/Job.h>
+#include <pasta/Util/ArgumentVector.h>
+#include <pasta/Util/Error.h>
+#include <pasta/Util/FileSystem.h>
+#include <pasta/Util/Init.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+static void DumpAST(pasta::AST ast) {
+
+}
+
+int main(int argc, char *argv[]) {
+  if (2 > argc) {
+    std::cerr << "Usage: " << argv[0] << " COMPILE_COMMAND..."
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  pasta::InitPasta initializer;
+
+  const auto cwd = std::filesystem::current_path().string();
+
+  auto maybe_compiler =
+      pasta::Compiler::CreateHostCompiler(pasta::TargetLanguage::kCXX);
+
+  if (pasta::IsError(maybe_compiler)) {
+    std::cerr << pasta::ErrorString(maybe_compiler) << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const auto compiler = std::move(*maybe_compiler);
+  //auto maybe_command = compiler.CreateCommandForFile(argv[1], cwd);
+  const pasta::ArgumentVector args(argc - 1, &argv[1]);
+  auto maybe_command = pasta::CompileCommand::CreateFromArguments(args, cwd);
+
+  if (pasta::IsError(maybe_command)) {
+    std::cerr << pasta::ErrorString(maybe_command) << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const auto command = std::move(*maybe_command);
+  auto maybe_jobs = compiler.CreateJobsForCommand(command);
+
+  if (pasta::IsError(maybe_jobs)) {
+    std::cerr << pasta::ErrorString(maybe_jobs) << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const auto jobs = std::move(*maybe_jobs);
+  for (const auto &job : jobs) {
+    auto maybe_ast = job.Run();
+    if (pasta::IsError(maybe_ast)) {
+      std::cerr << pasta::ErrorString(maybe_ast) << std::endl;
+      return EXIT_FAILURE;
+    } else {
+      DumpAST(std::move(*maybe_ast));
+    }
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/setup.py.in
+++ b/setup.py.in
@@ -31,7 +31,7 @@ if sys.platform.startswith("linux"):
 elif sys.platform == "darwin":
     extra_link_args = \
         ["-Wl,-force_load"] + \
-        ["$<TARGET_FILE:python_bindings>"] + \
+        ["$<TARGET_FILE:pasta_python_bindings>"] + \
         LIBRARY_PATHS + \
         ['-stdlib=libc++']
     extra_compile_args += ['-stdlib=libc++']


### PR DESCRIPTION
…d some issues in dds-native with conflicting lib names across some ToB projects, e.g. cxx_settings, thirdparty_llvm, etc. It breaks bootstrapping into separate cmakelists. It also adds a new in-progress target, dump-ast.