### PR TITLE
Fixes to compile against clang++-13

### DIFF
--- a/include/pasta/AST/DeclTail.h
+++ b/include/pasta/AST/DeclTail.h
@@ -11,7 +11,7 @@ struct hash<::pasta::Decl> {
   using Hasher = std::hash<const clang::Decl *>;
   static constexpr Hasher kHasher{};
 
-  inline Hasher::result_type operator()(
+  inline auto operator()(
       const ::pasta::Decl &decl) const noexcept {
     return kHasher(decl.RawDecl());
   }

--- a/lib/AST/AST.h
+++ b/lib/AST/AST.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <unordered_map>
 #include <variant>
+#include <mutex>
 
 #include "Token.h"
 

--- a/lib/Compile/Job.cpp
+++ b/lib/Compile/Job.cpp
@@ -258,16 +258,6 @@ CreateAdjustedCompilerCommand(FileSystemView &fs, const Compiler &compiler,
   unsigned output_id = 0;
   std::filesystem::path output_to_use;
 
-  unsigned backend_option_flags =
-      clang::driver::options::CC1Option |
-      clang::driver::options::CC1AsOption |
-      clang::driver::options::CoreOption |
-      clang::driver::options::NoDriverOption;
-  if (enable_cl) {
-    backend_option_flags &= ~static_cast<unsigned>(
-        clang::driver::options::CoreOption);
-  }
-
   std::string curr_lang;
 
 //  bool is_cc1 = !!args.getLastArg(clang::driver::options::OPT_cc1);


### PR DESCRIPTION
* use auto instead of return_type
* include <mutex>
* remove unused variable