### PR TITLE
fix cmake error when including project as subdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,11 @@ target_link_libraries(pasta_thirdparty_llvm INTERFACE
     clangIndex
 )
 
+target_include_directories(pasta_thirdparty_llvm INTERFACE
+    "$<BUILD_INTERFACE:${LLVM_INCLUDE_DIRS};${CLANG_INCLUDE_DIRS}>"
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
 # TODO(pag): Not sure if `Clang_DEFINITIONS` or `CLANG_DEFINITIONS`.
 target_compile_definitions(pasta_thirdparty_llvm INTERFACE
     ${LLVM_DEFINITIONS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,11 +114,6 @@ target_link_libraries(pasta_thirdparty_llvm INTERFACE
     clangIndex
 )
 
-target_include_directories(pasta_thirdparty_llvm INTERFACE
-    ${LLVM_INCLUDE_DIRS}
-    ${CLANG_INCLUDE_DIRS}
-)
-
 # TODO(pag): Not sure if `Clang_DEFINITIONS` or `CLANG_DEFINITIONS`.
 target_compile_definitions(pasta_thirdparty_llvm INTERFACE
     ${LLVM_DEFINITIONS}

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -12,17 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_program(ccache_path ccache)
-if("${ccache_path}" STREQUAL "ccache_path-NOTFOUND")
-  message(STATUS "ccache: Not found")
-else()
-  set(CMAKE_C_COMPILER_LAUNCHER "${ccache_path}")
-  set(CMAKE_CXX_COMPILER_LAUNCHER "${ccache_path}")
+if(PLATFORM_LINUX OR PLATFORM_MACOS)
+  find_program(ccache_executable "ccache")
+  if(NOT ccache_executable STREQUAL "ccache_executable-NOTFOUND")
+    message(STATUS "${PROJECT_NAME}: Enabling ccache support (${ccache_executable})")
 
-  set(ccache_dir "$ENV{CCACHE_DIR}")
-  if("${ccache_dir}" STREQUAL "")
-    set(ccache_dir "$ENV{HOME}/.ccache")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${ccache_executable}" CACHE FILEPATH "ccache")
+    set(CMAKE_C_COMPILER_LAUNCHER "${ccache_executable}" CACHE FILEPATH "ccache")
+
+  else()
+    message(STATUS "${PROJECT_NAME}: No ccache executable found")
   endif()
-
-  message(STATUS "ccache: enabled with '${ccache_path}'. The cache folder is located here: '${ccache_dir}'")
 endif()


### PR DESCRIPTION
```
CMake Error in vendor/pasta/CMakeLists.txt:
  Target "pasta_thirdparty_llvm" INTERFACE_INCLUDE_DIRECTORIES property
  contains path:

    "/app/vendor/vcpkg_ubuntu-20.04_llvm-14_arm64/installed/arm64-linux-rel/include"

  which is prefixed in the source directory.


CMake Error in vendor/pasta/CMakeLists.txt:
  Target "pasta_thirdparty_llvm" INTERFACE_INCLUDE_DIRECTORIES property
  contains path:

    "/app/vendor/vcpkg_ubuntu-20.04_llvm-14_arm64/installed/arm64-linux-rel/include"

  which is prefixed in the source directory.
```