### PR TITLE
Don't exit with success until all compile jobs are finished.

### DIFF
--- a/bin/DumpAST/Main.cpp
+++ b/bin/DumpAST/Main.cpp
@@ -137,7 +137,6 @@ int main(int argc, char *argv[]) {
       std::cerr << maybe_ast.TakeError() << std::endl;
       return EXIT_FAILURE;
     } else {
-      return EXIT_SUCCESS;
       DumpAST(maybe_ast.TakeValue());
     }
   }


### PR DESCRIPTION
Just testing creating a PR for PASTA with this small fix to the AST dumper.