### PR TITLE
Add methods to Stmt for getting covering macro substitutions and containing macro arguments

### DIFF
--- a/bin/BootstrapTypes/GenerateStmtH.cpp
+++ b/bin/BootstrapTypes/GenerateStmtH.cpp
@@ -92,7 +92,9 @@ void GenerateStmtH(void) {
 
     if (name_ref == "Stmt") {
       os << "  friend class TokenContext;\n"
-         << "  static std::optional<::pasta::Stmt> From(const TokenContext &);\n";
+         << "  static std::optional<::pasta::Stmt> From(const TokenContext &);\n"
+         << "  std::optional<::pasta::Macro> GetCoveringSubstitution(void) const noexcept;\n"
+         << "  std::optional<::pasta::MacroArgument> GetLowestContainingMacroArgument(void) const noexcept;\n";
     }
 
     // Constructors from derived class -> base class.
@@ -124,8 +126,6 @@ void GenerateStmtH(void) {
 
       os
           << "    const void *opaque;\n"
-          << "    std::optional<::pasta::Macro> GetCoveringSubstitution() const noexcept;\n"
-          << "    std::optional<::pasta::MacroArgument> GetLowestContainingMacroArgument() const noexcept;\n"
           << "  } u;\n"
           << "  StmtKind kind;\n\n"
           << "  inline explicit Stmt(std::shared_ptr<ASTImpl> ast_,\n"

--- a/bin/BootstrapTypes/GenerateStmtH.cpp
+++ b/bin/BootstrapTypes/GenerateStmtH.cpp
@@ -31,6 +31,7 @@ void GenerateStmtH(void) {
       << "#include \"Attr.h\"\n"
       << "#include \"DeclHead.h\"\n\n"
       << "#include \"StmtManual.h\"\n\n"
+      << "#include \"Macro.h\"\n\n"
       << "#define PASTA_DEFINE_DEFAULT_STMT_CONSTRUCTOR(base) \\\n"
       << "    friend class AST; \\\n"
       << "    friend class ASTImpl; \\\n"
@@ -123,6 +124,8 @@ void GenerateStmtH(void) {
 
       os
           << "    const void *opaque;\n"
+          << "    std::optional<::pasta::Macro> GetCoveringSubstitution() const noexcept;\n"
+          << "    std::optional<::pasta::MacroArgument> GetLowestContainingMacroArgument() const noexcept;\n"
           << "  } u;\n"
           << "  StmtKind kind;\n\n"
           << "  inline explicit Stmt(std::shared_ptr<ASTImpl> ast_,\n"

--- a/bin/BootstrapTypes/GenerateStmtH.cpp
+++ b/bin/BootstrapTypes/GenerateStmtH.cpp
@@ -93,8 +93,8 @@ void GenerateStmtH(void) {
     if (name_ref == "Stmt") {
       os << "  friend class TokenContext;\n"
          << "  static std::optional<::pasta::Stmt> From(const TokenContext &);\n"
-         << "  std::optional<::pasta::Macro> GetCoveringSubstitution(void) const noexcept;\n"
-         << "  std::optional<::pasta::MacroArgument> GetLowestContainingMacroArgument(void) const noexcept;\n";
+         << "  std::optional<::pasta::Macro> CoveringSubstitution(void) const noexcept;\n"
+         << "  std::optional<::pasta::MacroArgument> LowestContainingMacroArgument(void) const noexcept;\n";
     }
 
     // Constructors from derived class -> base class.

--- a/lib/AST/StmtManual.cpp
+++ b/lib/AST/StmtManual.cpp
@@ -24,7 +24,7 @@ namespace pasta {
 // Follow a macro token's parent chain to the end, and returns the final parent.
 // If the macro token has no parent, this returns std::nullopt;
 std::optional<Macro>
-GetRootSubstitution(const MacroToken &macro_token) noexcept {
+RootSubstitution(const MacroToken &macro_token) noexcept {
   std::optional<Macro> root;
   std::optional<Macro> next_root = macro_token.Parent();
   do {
@@ -35,7 +35,7 @@ GetRootSubstitution(const MacroToken &macro_token) noexcept {
 }
 
 // Returns the highest substitution that covers this Stmt, if any.
-std::optional<Macro> Stmt::GetCoveringSubstitution(void) const noexcept {
+std::optional<Macro> Stmt::CoveringSubstitution(void) const noexcept {
   // If the first token in this Stmt did not come from a macro substitution,
   // then this Stmt is not covered by a substitution
   const auto begin_macro_token = BeginToken().MacroLocation();
@@ -50,8 +50,8 @@ std::optional<Macro> Stmt::GetCoveringSubstitution(void) const noexcept {
     return std::nullopt;
   }
 
-  const auto begin_macro_token_root = GetRootSubstitution(*begin_macro_token);
-  const auto end_macro_token_root = GetRootSubstitution(*end_macro_token);
+  const auto begin_macro_token_root = RootSubstitution(*begin_macro_token);
+  const auto end_macro_token_root = RootSubstitution(*end_macro_token);
 
   // If the root of the begin token and end token are the same, then return that
   // root
@@ -85,7 +85,7 @@ inline bool IsTokenDerivedFromMacro(const Token &token, const Macro &macro) {
 
 // Returns the lowest macro argument that contains this Stmt, if any.
 std::optional<MacroArgument>
-Stmt::GetLowestContainingMacroArgument(void) const noexcept {
+Stmt::LowestContainingMacroArgument(void) const noexcept {
   // Algorithm:
   // 1. Find the lowest macro argument that the first token in this Stmt was
   //    expanded from.


### PR DESCRIPTION
GetLowestContainingMacroArgument to pasta::Stmt.
GetCoveringSubstitution returns the highest macro substitution that covers the Stmt, or std::nullopt if the Stmt is not covered by a macro substitution.
GetLowestContainingMacroArgument returns the lowest macro argument that contains the Stmt, or std::nullopt if no macro argument contains the Stmt.
Also add the helper methods GetRootSubstitution and IsTokenDerivedFromMacro for GetCoveringSubstitution and GetLowestContainingMacroArgument, respectively.