### PR TITLE
MacroSubstitution Stmt and Decl covering methods

### DIFF
--- a/bin/BootstrapTypes/GenerateStmtH.cpp
+++ b/bin/BootstrapTypes/GenerateStmtH.cpp
@@ -95,7 +95,7 @@ void GenerateStmtH(void) {
     if (name_ref == "Stmt") {
       os << "  friend class TokenContext;\n"
          << "  static std::optional<::pasta::Stmt> From(const TokenContext &);\n"
-         << "  std::optional<::pasta::Macro> CoveringSubstitution(void) const noexcept;\n"
+         << "  std::optional<::pasta::Macro> HighestContainingSubstitution(void) const noexcept;\n"
          << "  std::optional<::pasta::MacroArgument> LowestContainingMacroArgument(void) const noexcept;\n";
     }
 

--- a/include/pasta/AST/DeclBootstrap.h
+++ b/include/pasta/AST/DeclBootstrap.h
@@ -7,6 +7,7 @@
 #ifdef PASTA_IN_BOOTSTRAP
 
 #include <memory>
+#include <optional>
 #include <string_view>
 
 namespace clang {
@@ -17,6 +18,8 @@ namespace pasta {
 class AST;
 class ASTImpl;
 enum class DeclKind : unsigned;
+class Token;
+class TokenContext;
 
 class Decl {
  public:
@@ -44,6 +47,10 @@ class Decl {
   inline const clang::Decl *RawDecl(void) const noexcept {
     return u.Decl;
   }
+
+  static std::optional<Decl> From(const TokenContext &);
+  Token BeginToken(void) const noexcept;
+  Token EndToken(void) const noexcept;
 
  private:
   Decl(void) = delete;

--- a/include/pasta/AST/Macro.h
+++ b/include/pasta/AST/Macro.h
@@ -381,11 +381,11 @@ class MacroSubstitution : public Macro {
 
   // Returns the Stmt in the AST that was parsed from the tokens this macro
   // substitution expanded to, if any.
-  std::optional<Stmt> GetCoveredStmt(void) const noexcept;
+  std::optional<Stmt> CoveredStmt(void) const noexcept;
 
   // Returns the Decl in the AST that was parsed from the tokens this macro
   // substitution expanded to, if any.
-  std::optional<Decl> GetCoveredDecl(void) const noexcept;
+  std::optional<Decl> CoveredDecl(void) const noexcept;
 };
 
 static_assert(sizeof(MacroSubstitution) == sizeof(Macro));

--- a/include/pasta/AST/Macro.h
+++ b/include/pasta/AST/Macro.h
@@ -14,6 +14,7 @@ namespace pasta {
 
 class AST;
 class ASTImpl;
+class Decl;
 class File;
 class FileToken;
 class FileTokenRange;
@@ -37,6 +38,7 @@ class MacroTokenImpl;
 class PatchedMacroTracker;
 class SkippedTokenRange;
 class SkippedTokenRangeImpl;
+class Stmt;
 class Token;
 class TokenContext;
 class TokenImpl;
@@ -117,12 +119,13 @@ class Macro {
 
   const void *RawMacro(void) const noexcept;
 
-  inline std::strong_ordering operator<=>(const Macro &that) const noexcept {
-    return RawMacro() <=> that.RawMacro();
+  inline bool operator==(const Macro &that) const noexcept {
+    return RawMacro() == that.RawMacro();
   }
 
-  bool operator==(const Macro &) const noexcept = default;
-  bool operator!=(const Macro &) const noexcept = default;
+  inline bool operator!=(const Macro &that) const noexcept {
+    return RawMacro() != that.RawMacro();
+  }
 
   // Return the macro node containing this node.
   std::optional<Macro> Parent(void) const noexcept;
@@ -375,6 +378,14 @@ class MacroSubstitution : public Macro {
   }
 
   MacroRange ReplacementChildren(void) const noexcept;
+
+  // Returns the Stmt in the AST that was parsed from the tokens this macro
+  // substitution expanded to, if any.
+  std::optional<Stmt> GetCoveredStmt(void) const noexcept;
+
+  // Returns the Decl in the AST that was parsed from the tokens this macro
+  // substitution expanded to, if any.
+  std::optional<Decl> GetCoveredDecl(void) const noexcept;
 };
 
 static_assert(sizeof(MacroSubstitution) == sizeof(Macro));

--- a/include/pasta/AST/Stmt.h
+++ b/include/pasta/AST/Stmt.h
@@ -297,7 +297,7 @@ class Stmt {
   friend class TokenContext;
   static std::optional<::pasta::Stmt> From(const TokenContext &);
 
-  std::optional<::pasta::Macro> CoveringSubstitution(void) const noexcept;
+  std::optional<::pasta::Macro> HighestContainingSubstitution(void) const noexcept;
   std::optional<::pasta::MacroArgument> LowestContainingMacroArgument(void) const noexcept;
 
   PASTA_DECLARE_DERIVED_OPERATORS(Stmt, AbstractConditionalOperator)

--- a/include/pasta/AST/StmtBootstrap.h
+++ b/include/pasta/AST/StmtBootstrap.h
@@ -7,6 +7,7 @@
 #ifdef PASTA_IN_BOOTSTRAP
 
 #include <memory>
+#include <optional>
 #include <string_view>
 
 namespace clang {
@@ -17,6 +18,8 @@ namespace pasta {
 class AST;
 class ASTImpl;
 enum class StmtKind : unsigned;
+class Token;
+class TokenContext;
 
 class Stmt {
  public:
@@ -40,6 +43,10 @@ class Stmt {
   }
 
   std::string_view KindName(void) const noexcept;
+
+  static std::optional<Stmt> From(const TokenContext &);
+  Token BeginToken(void) const noexcept;
+  Token EndToken(void) const noexcept;
 
  private:
   Stmt(void) = delete;

--- a/lib/AST/StmtManual.cpp
+++ b/lib/AST/StmtManual.cpp
@@ -35,7 +35,7 @@ RootSubstitution(const MacroToken &macro_token) noexcept {
 }
 
 // Returns the highest substitution that covers this Stmt, if any.
-std::optional<Macro> Stmt::CoveringSubstitution(void) const noexcept {
+std::optional<Macro> Stmt::HighestContainingSubstitution(void) const noexcept {
   // If the first token in this Stmt did not come from a macro substitution,
   // then this Stmt is not covered by a substitution
   const auto begin_macro_token = BeginToken().MacroLocation();


### PR DESCRIPTION
Add methods to MacroSubstitution to get the lowest Stmt and Decl that the substitution completely covers.
Change equality comparisons between Macro objects to use the RawMacro() method