### PR TITLE
Color token roles in PrintMacroGraph

### DIFF
--- a/include/pasta/AST/Token.h
+++ b/include/pasta/AST/Token.h
@@ -50,22 +50,31 @@ class TokenPrinterContext;
 class TokenImpl;
 class TokenRange;
 
+// X-macro for repeated operations on TokenRole values
+#define ROLES \
+  ROLE(Invalid) \
+  ROLE(BeginOfFileMarker) \
+  ROLE(FileToken) \
+  ROLE(EndOfFileMarker) \
+  ROLE(BeginOfMacroExpansionMarker) \
+  ROLE(InitialMacroUseToken) \
+  ROLE(IntermediateMacroExpansionToken) \
+  ROLE(FinalMacroExpansionToken) \
+  ROLE(EndOfMacroExpansionMarker) \
+  ROLE(EndOfInternalMacroEventMarker) \
+
 enum class TokenKind : unsigned short;
 enum class TokenRole : std::underlying_type_t<TokenKind> {
-  kInvalid,
-
-  kBeginOfFileMarker,
-  kFileToken,
-  kEndOfFileMarker,
-
-  kBeginOfMacroExpansionMarker,
-  kInitialMacroUseToken,
-  kIntermediateMacroExpansionToken,
-  kFinalMacroExpansionToken,
-  kEndOfMacroExpansionMarker,
-
-  kEndOfInternalMacroEventMarker,
+  #define ROLE(role) k ## role ,
+  ROLES
+  #undef ROLE
 };
+
+// Vector of all token roles for iteration.
+extern std::vector<TokenRole> TokenRoles;
+
+// Returns the name of the specified TokenRole as a string.
+std::string TokenRoleName(const TokenRole role);
 
 enum class TokenContextKind : unsigned char {
   kInvalid,

--- a/lib/AST/Token.cpp
+++ b/lib/AST/Token.cpp
@@ -179,6 +179,21 @@ static bool ReadRawTokenData(clang::SourceManager &source_manager,
 
 } // namespace
 
+std::vector<pasta::TokenRole> TokenRoles = std::vector({
+  #define ROLE(role) TokenRole::k##role ,
+  ROLES
+  #undef ROLE
+});
+
+std::string TokenRoleName(const TokenRole role) {
+  const static std::string TokenRoleNames[] = {
+#define ROLE(role) #role,
+  ROLES
+#undef ROLE
+  };
+  return TokenRoleNames[static_cast<size_t>(role)];
+}
+
 // Return the common ancestor between two contexts. This focuses on the data
 // itself, so if there are two distinct contexts sharing the same data, or
 // aliasing the same data, the context associated with the second token is


### PR DESCRIPTION
- Add a feature for the macro graph printer to optionally print tokens in different colors based on their roles.
- Add a configuration macro, PRINT_ROLE_COLORS, to enable/disable this feature.
- Make several adjustments to the TokenRole enum class to make development of this feature and future features involving token roles easier:
  - Add an X-macro, ROLES, for performing metaprogramming actions to all TokenRole enumerators.
  - Use ROLES macro to define a global vector containing all TokenRole enumerators to make it possible to iterate all roles.
  - Use ROLES macro to define a function for stringifying TokenRole enumerators.