### PR TITLE
Rename method CoveringSubstitution

### DIFF
--- a/bin/BootstrapTypes/GenerateStmtH.cpp
+++ b/bin/BootstrapTypes/GenerateStmtH.cpp
@@ -95,7 +95,7 @@ void GenerateStmtH(void) {
     if (name_ref == "Stmt") {
       os << "  friend class TokenContext;\n"
          << "  static std::optional<::pasta::Stmt> From(const TokenContext &);\n"
-         << "  std::optional<::pasta::Macro> CoveringSubstitution(void) const noexcept;\n"
+         << "  std::optional<::pasta::Macro> HighestContainingSubstitution(void) const noexcept;\n"
          << "  std::optional<::pasta::MacroArgument> LowestContainingMacroArgument(void) const noexcept;\n";
     }
 

--- a/include/pasta/AST/Stmt.h
+++ b/include/pasta/AST/Stmt.h
@@ -297,7 +297,7 @@ class Stmt {
   friend class TokenContext;
   static std::optional<::pasta::Stmt> From(const TokenContext &);
 
-  std::optional<::pasta::Macro> CoveringSubstitution(void) const noexcept;
+  std::optional<::pasta::Macro> HighestContainingSubstitution(void) const noexcept;
   std::optional<::pasta::MacroArgument> LowestContainingMacroArgument(void) const noexcept;
 
   PASTA_DECLARE_DERIVED_OPERATORS(Stmt, AbstractConditionalOperator)

--- a/lib/AST/StmtManual.cpp
+++ b/lib/AST/StmtManual.cpp
@@ -35,7 +35,7 @@ RootSubstitution(const MacroToken &macro_token) noexcept {
 }
 
 // Returns the highest substitution that covers this Stmt, if any.
-std::optional<Macro> Stmt::CoveringSubstitution(void) const noexcept {
+std::optional<Macro> Stmt::HighestContainingSubstitution(void) const noexcept {
   // If the first token in this Stmt did not come from a macro substitution,
   // then this Stmt is not covered by a substitution
   const auto begin_macro_token = BeginToken().MacroLocation();


### PR DESCRIPTION
Rename the method CoveringSubstitution to HighestContainingSubstitution to more accurately reflect the method's expected behavior.