### PR TITLE
Ignore .vscode directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ install/*
 .clion
 .project
 .settings
-
+.vscode/


### PR DESCRIPTION
Ignore the settings directory .vscode for contributors who develop in Visual Studio Code.