### PR TITLE
Print macro name fix

### DIFF
--- a/bin/PrintAlignedParameterSubstitutions/Main.cpp
+++ b/bin/PrintAlignedParameterSubstitutions/Main.cpp
@@ -68,16 +68,15 @@ public:
         PrintTokensTo(ss, stmt.Tokens());
         ss << " is covered by the following expansions:\n";
         for (auto &exp : covering_expansions) {
-          ss << exp.BeginToken()->Data() << '\n';
+          ss << exp.Name() << '\n';
           ss << "Aligned parameters:\n";
           auto aligned_parameters = exp.AlignedParameterSubstitutions(stmt);
           auto parameter_use_counts = exp.ParameterUseCounts();
-          auto def = exp.Definition().value();
           for (auto &[param, param_stmts] : aligned_parameters) {
-            auto param_name = param.BeginToken();
             unsigned expected = parameter_use_counts.at(param);
+            auto param_name  = param.Name();
             std::size_t actual = param_stmts.size();
-            ss << "  " << (param_name ? param_name->Data() : "<unnamed>")
+            ss << "  " << (param_name ? param_name->Data() : "<a nameless parameter>")
               << " (expected " << std::to_string(expected)
               << ", actual " << std::to_string(actual)
               << "):\n";
@@ -193,8 +192,7 @@ int main(int argc, char *argv[]) {
     if (!maybe_ast.Succeeded()) {
       std::cerr << maybe_ast.TakeError() << std::endl;
       return EXIT_FAILURE;
-    }
-    else {
+    } else {
       PrintAlignedParameterSubstitutions(maybe_ast.TakeValue());
     }
   }

--- a/bin/PrintAlignedParameterSubstitutions/Main.cpp
+++ b/bin/PrintAlignedParameterSubstitutions/Main.cpp
@@ -68,8 +68,12 @@ public:
         PrintTokensTo(ss, stmt.Tokens());
         ss << " is covered by the following expansions:\n";
         for (auto &exp : covering_expansions) {
-          ss << exp.Name() << '\n';
-          ss << "Aligned parameters:\n";
+          if (auto name = exp.NameOrOperator()) {
+            ss << name->Data();
+          } else {
+            ss << "<a nameless macro>";
+          }
+          ss << "\nAligned parameters:\n";
           auto aligned_parameters = exp.AlignedParameterSubstitutions(stmt);
           auto parameter_use_counts = exp.ParameterUseCounts();
           for (auto &[param, param_stmts] : aligned_parameters) {

--- a/bin/PrintCoveringMacros/Main.cpp
+++ b/bin/PrintCoveringMacros/Main.cpp
@@ -60,7 +60,11 @@ public:
             ss << ' ';
           }
           if (auto sub = pasta::MacroSubstitution::From(macro)) {
-            ss << sub->Name();
+            if (auto name = sub->NameOrOperator()) {
+              ss << name->Data();
+            } else {
+              ss << "<a nameless macro>";
+            }
           } else if (auto bt = macro.BeginToken()) {
             ss << bt->Data();
           } else {

--- a/bin/PrintMacroGraph/Main.cpp
+++ b/bin/PrintMacroGraph/Main.cpp
@@ -64,7 +64,7 @@ static inline std::string TokRoleColor(const pasta::TokenRole role) {
   case pasta::TokenRole::kEndOfInternalMacroEventMarker: ss << "pink"; break;
 
   default:
-    assert(!"unknown token role");
+    assert(false && "unknown token role");
   }
   return ss.str();
 }

--- a/include/pasta/AST/Macro.h
+++ b/include/pasta/AST/Macro.h
@@ -399,6 +399,10 @@ class MacroSubstitution : public Macro {
   // Returns the Decl in the AST that was parsed from the tokens this macro
   // substitution expanded to, if any.
   std::optional<Decl> CoveredDecl(void) const noexcept;
+
+  // Returns the name of the substituted macro if it has one, or the reason why
+  // it does not.
+  std::string_view Name(void) const noexcept;
 };
 
 static_assert(sizeof(MacroSubstitution) == sizeof(Macro));

--- a/include/pasta/AST/Macro.h
+++ b/include/pasta/AST/Macro.h
@@ -156,6 +156,7 @@ class MacroToken final : public Macro {
   friend class MacroParameter;
   friend class MacroParameterSubstitution;
   friend class MacroStringify;
+  friend class MacroSubstitution;
   friend class Token;
 
   using Macro::Macro;
@@ -400,9 +401,10 @@ class MacroSubstitution : public Macro {
   // substitution expanded to, if any.
   std::optional<Decl> CoveredDecl(void) const noexcept;
 
-  // Returns the name of the substituted macro if it has one, or the reason why
-  // it does not.
-  std::string_view Name(void) const noexcept;
+  // Returns the name of the substituted macro if any. If this substitution
+  // comes from a stringification or token-pasting macro, then return the
+  // operator that triggered the operation instead.
+  std::optional<MacroToken> NameOrOperator(void) const noexcept;
 };
 
 static_assert(sizeof(MacroSubstitution) == sizeof(Macro));

--- a/lib/AST/Macro.cpp
+++ b/lib/AST/Macro.cpp
@@ -1050,6 +1050,32 @@ std::optional<Decl> MacroSubstitution::CoveredDecl(void) const noexcept {
   return std::nullopt;
 }
 
+std::string_view MacroSubstitution::Name(void) const noexcept {
+  if (auto exp = pasta::MacroExpansion::From(*this)) {
+    if (auto def = exp->Definition()) {
+      if (auto name = def->Name()) {
+        return name->Data();
+      } else {
+        return "<a nameless expansion>";
+      }
+    } else {
+      return "<an expansion without a definition>";
+    }
+  } else if (auto param_sub = pasta::MacroParameterSubstitution::From(*this)) {
+    if (auto name = param_sub->Parameter().Name()) {
+      return name->Data();
+    } else {
+      return "<a nameless parameter>";
+    }
+  } else if (auto stringify = pasta::MacroStringify::From(*this)) {
+    return "<a macro stringification>";
+  } else if (auto concat = pasta::MacroConcatenate::From(*this)) {
+    return "<a macro concatenation>";
+  } else {
+    return "<an unknown kind of macro substitution>";
+  }
+}
+
 // Walks the given Stmt's subtree and returns the first of its subtrees that
 // aligns with the given macro, if any.
 std::optional<pasta::Stmt>

--- a/lib/AST/Macro.cpp
+++ b/lib/AST/Macro.cpp
@@ -1050,30 +1050,12 @@ std::optional<Decl> MacroSubstitution::CoveredDecl(void) const noexcept {
   return std::nullopt;
 }
 
-std::string_view MacroSubstitution::Name(void) const noexcept {
-  if (auto exp = pasta::MacroExpansion::From(*this)) {
-    if (auto def = exp->Definition()) {
-      if (auto name = def->Name()) {
-        return name->Data();
-      } else {
-        return "<a nameless expansion>";
-      }
-    } else {
-      return "<an expansion without a definition>";
-    }
-  } else if (auto param_sub = pasta::MacroParameterSubstitution::From(*this)) {
-    if (auto name = param_sub->Parameter().Name()) {
-      return name->Data();
-    } else {
-      return "<a nameless parameter>";
-    }
-  } else if (auto stringify = pasta::MacroStringify::From(*this)) {
-    return "<a macro stringification>";
-  } else if (auto concat = pasta::MacroConcatenate::From(*this)) {
-    return "<a macro concatenation>";
-  } else {
-    return "<an unknown kind of macro substitution>";
-  }
+std::optional<MacroToken> MacroSubstitution::NameOrOperator(void) const noexcept {
+  auto node = *reinterpret_cast<const Node *>(impl);
+  auto *node_impl = std::get<MacroNodeImpl *>(node);
+  auto *sub_impl = dynamic_cast<MacroSubstitutionImpl *>(node_impl);
+  assert(std::holds_alternative<MacroTokenImpl *>(sub_impl->name));
+  return MacroToken(ast, &sub_impl->name);
 }
 
 // Walks the given Stmt's subtree and returns the first of its subtrees that

--- a/lib/AST/Macro.h
+++ b/lib/AST/Macro.h
@@ -182,6 +182,7 @@ class MacroSubstitutionImpl : public MacroNodeImpl {
   MacroNodeImpl *Clone(ASTImpl &ast, MacroNodeImpl *parent) const override;
 
   NodeList use_nodes;
+  Node name;
 };
 
 class MacroParameterSubstitutionImpl final : public MacroSubstitutionImpl {

--- a/test/MacroCoveringAndContainingTests/function_like.c
+++ b/test/MacroCoveringAndContainingTests/function_like.c
@@ -8,6 +8,133 @@
 // RUN: print-aligned-parameter-substitutions %s \
 // RUN: | FileCheck %s -check-prefix=PAPS
 
+// PLCMA: 0 is contained in argument of parent macro expansion of macro definition ADD argument number 0 X
+// PLCMA: 1 is contained in argument of parent macro expansion of macro definition ADD argument number 1 Y
+// PLCMA: 2 is contained in argument of parent macro expansion of macro definition ADD argument number 0 X
+// PLCMA: 3 is contained in argument of parent macro expansion of macro definition ADD argument number 1 Y
+// PLCMA: 1 * 2 is contained in argument of parent macro expansion of macro definition ADD argument number 0 X
+// PLCMA: 1 is contained in argument of parent macro expansion of macro definition MUL argument number 0 X
+// PLCMA: 2 is contained in argument of parent macro expansion of macro definition MUL argument number 1 Y
+// PLCMA: 3 * 4 is contained in argument of parent macro expansion of macro definition ADD argument number 1 Y
+// PLCMA: 3 is contained in argument of parent macro expansion of macro definition MUL argument number 0 X
+// PLCMA: 4 is contained in argument of parent macro expansion of macro definition MUL argument number 1 Y
+// PLCMA: 2 is contained in argument of parent macro expansion of macro definition ADD argument number 0 X
+// PLCMA: 3 is contained in argument of parent macro expansion of macro definition ADD argument number 1 Y
+// PLCMA: x is contained in argument of parent macro expansion of macro definition DO_NOT_SWALLOW_SEMICOLON argument number 0 X
+// PLCMA: 1 is contained in argument of parent macro expansion of macro definition COMMAS argument number 0 ...
+// PLCMA: 1 is contained in argument of parent macro expansion of macro definition COMMAS argument number 0 ...
+// PLCMA: 2 is contained in argument of parent macro expansion of macro definition COMMAS argument number 1 <unnamed>
+// PLCMA: 1 is contained in argument of parent macro expansion of macro definition VA_OPT_TEST argument number 0 ...
+// PLCMA: 2 is contained in argument of parent macro expansion of macro definition VA_OPT_TEST argument number 1 <unnamed>
+// PLCMA: 3 is contained in argument of parent macro expansion of macro definition VA_OPT_TEST argument number 2 <unnamed>
+
+// PHCS: 0 + 1 is contained in ADD at the highest level
+// PHCS: 0 is contained in ADD at the highest level
+// PHCS: 1 is contained in ADD at the highest level
+// PHCS: 2 is contained in ADD at the highest level
+// PHCS: 3 is contained in ADD at the highest level
+// PHCS: "FIZZ" "and" "BUZZ" is contained in FIZZ_AND at the highest level
+// PHCS: 1 * 2 + 3 * 4 is contained in ADD at the highest level
+// PHCS: 1 * 2 is contained in ADD at the highest level
+// PHCS: 1 is contained in ADD at the highest level
+// PHCS: 2 is contained in ADD at the highest level
+// PHCS: 3 * 4 is contained in ADD at the highest level
+// PHCS: 3 is contained in ADD at the highest level
+// PHCS: 4 is contained in ADD at the highest level
+// PHCS: 1 + 2 + 3 is contained in STRANGE at the highest level
+// PHCS: 1 + 2 is contained in STRANGE at the highest level
+// PHCS: 1 is contained in STRANGE at the highest level
+// PHCS: 2 is contained in STRANGE at the highest level
+// PHCS: 3 is contained in STRANGE at the highest level
+// PHCS: do { x ++ ; } while ( 0 ) is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
+// PHCS: { x ++ ; } is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
+// PHCS: x ++ is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
+// PHCS: x is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
+// PHCS: 0 is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
+// PHCS: 1 is contained in COMMAS at the highest level
+// PHCS: 1 , 2 is contained in COMMAS at the highest level
+// PHCS: 1 is contained in COMMAS at the highest level
+// PHCS: 2 is contained in COMMAS at the highest level
+// PHCS: 1 is contained in VA_OPT_TEST at the highest level
+// PHCS: 1 , 1 , 2 , 3 is contained in VA_OPT_TEST at the highest level
+// PHCS: 1 , 1 , 2 is contained in VA_OPT_TEST at the highest level
+// PHCS: 1 , 1 is contained in VA_OPT_TEST at the highest level
+// PHCS: 1 is contained in VA_OPT_TEST at the highest level
+// PHCS: 1 is contained in VA_OPT_TEST at the highest level
+// PHCS: 2 is contained in VA_OPT_TEST at the highest level
+// PHCS: 3 is contained in VA_OPT_TEST at the highest level
+// PHCS: "string" is contained in STRINGIFY at the highest level
+// PHCS: "one" , "two" is contained in STRINGIFY_SEP_COMMAS at the highest level
+// PHCS: "one" is contained in STRINGIFY_SEP_COMMAS at the highest level
+// PHCS: "two" is contained in STRINGIFY_SEP_COMMAS at the highest level
+// PHCS: 1234 is contained in PASTE at the highest level
+
+// PLCSD: ADD covers 0 + 1
+// PLCSD: ADD covers nothing
+// PLCSD: FIZZ_AND covers "FIZZ" "and" "BUZZ"
+// PLCSD: ADD covers 1 * 2 + 3 * 4
+// PLCSD: STRANGE covers 1 + 2 + 3
+// PLCSD: DECLARE_GENERIC_FUNC_f covers int l_UNIQUE ( ) ;
+// PLCSD: DECLARE_GENERIC_FUNC_g covers char m_UNIQUE ( void ) ;
+// PLCSD: DECLARE_FUNC_PTR_GENERIC_h covers int * ( * n_UNIQUE ) ( ) ;
+// PLCSD: DO_NOT_SWALLOW_SEMICOLON covers do { x ++ ; } while ( 0 )
+// PLCSD: COMMAS covers 1
+// PLCSD: COMMAS covers 1 , 2
+// PLCSD: VA_OPT_TEST covers 1
+// PLCSD: VA_OPT_TEST covers 1 , 1 , 2 , 3
+// PLCSD: STRINGIFY covers "string"
+// PLCSD: STRINGIFY_SEP_COMMAS covers "one" , "two"
+// PLCSD: PASTE covers 1234
+
+// PLCM: 0 + 1 is covered by ADD at the lowest level
+// PLCM: 0 is covered by X at the lowest level
+// PLCM: 0 is covered by argument of parent macro expansion of macro definition ADD argument number 0 X
+// PLCM: 1 is covered by Y at the lowest level
+// PLCM: 1 is covered by argument of parent macro expansion of macro definition ADD argument number 1 Y
+// PLCM: 2 is covered by X at the lowest level
+// PLCM: 2 is covered by argument of parent macro expansion of macro definition ADD argument number 0 X
+// PLCM: 3 is covered by Y at the lowest level
+// PLCM: 3 is covered by argument of parent macro expansion of macro definition ADD argument number 1 Y
+// PLCM: "FIZZ" "and" "BUZZ" is covered by FIZZ_AND at the lowest level
+// PLCM: 1 * 2 + 3 * 4 is covered by ADD at the lowest level
+// PLCM: 1 * 2 is covered by MUL at the lowest level
+// PLCM: 1 * 2 is covered by X at the lowest level
+// PLCM: 1 * 2 is covered by argument of parent macro expansion of macro definition ADD argument number 0 X
+// PLCM: 1 is covered by X at the lowest level
+// PLCM: 1 is covered by argument of parent macro expansion of macro definition MUL argument number 0 X
+// PLCM: 2 is covered by Y at the lowest level
+// PLCM: 2 is covered by argument of parent macro expansion of macro definition MUL argument number 1 Y
+// PLCM: 3 * 4 is covered by MUL at the lowest level
+// PLCM: 3 * 4 is covered by Y at the lowest level
+// PLCM: 3 * 4 is covered by argument of parent macro expansion of macro definition ADD argument number 1 Y
+// PLCM: 3 is covered by X at the lowest level
+// PLCM: 3 is covered by argument of parent macro expansion of macro definition MUL argument number 0 X
+// PLCM: 4 is covered by Y at the lowest level
+// PLCM: 4 is covered by argument of parent macro expansion of macro definition MUL argument number 1 Y
+// PLCM: 1 + 2 + 3 is covered by STRANGE at the lowest level
+// PLCM: 2 is covered by X at the lowest level
+// PLCM: 2 is covered by argument of parent macro expansion of macro definition ADD argument number 0 X
+// PLCM: 3 is covered by Y at the lowest level
+// PLCM: 3 is covered by argument of parent macro expansion of macro definition ADD argument number 1 Y
+// PLCM: do { x ++ ; } while ( 0 ) is covered by DO_NOT_SWALLOW_SEMICOLON at the lowest level
+// PLCM: x is covered by X at the lowest level
+// PLCM: x is covered by argument of parent macro expansion of macro definition DO_NOT_SWALLOW_SEMICOLON argument number 0 X
+// PLCM: 1 is covered by COMMAS at the lowest level
+// PLCM: 1 is covered by __VA_ARGS__ at the lowest level
+// PLCM: 1 is covered by argument of parent macro expansion of macro definition COMMAS argument number 0 ...
+// PLCM: 1 , 2 is covered by COMMAS at the lowest level
+// PLCM: 1 , 2 is covered by __VA_ARGS__ at the lowest level
+// PLCM: 1 is covered by argument of parent macro expansion of macro definition COMMAS argument number 0 ...
+// PLCM: 2 is covered by argument of parent macro expansion of macro definition COMMAS argument number 1 <unnamed>
+// PLCM: 1 is covered by VA_OPT_TEST at the lowest level
+// PLCM: 1 , 1 , 2 , 3 is covered by VA_OPT_TEST at the lowest level
+// PLCM: 1 is covered by argument of parent macro expansion of macro definition VA_OPT_TEST argument number 0 ...
+// PLCM: 2 is covered by argument of parent macro expansion of macro definition VA_OPT_TEST argument number 1 <unnamed>
+// PLCM: 3 is covered by argument of parent macro expansion of macro definition VA_OPT_TEST argument number 2 <unnamed>
+// PLCM: "string" is covered by STRINGIFY at the lowest level
+// PLCM: "one" , "two" is covered by STRINGIFY_SEP_COMMAS at the lowest level
+// PLCM: 1234 is covered by PASTE at the lowest level
+
 // PCM: 0 + 1 is covered by ADD (kExpansion) ADD (kExpansion)
 // PCM: 0 is covered by 0 (kArgument) 0 (kArgument) X (kParameterSubstitution)
 // PCM: 1 is covered by 1 (kArgument) 1 (kArgument) Y (kParameterSubstitution)
@@ -26,6 +153,20 @@
 // PCM: 3 is covered by 3 (kArgument) 3 (kArgument) Y (kParameterSubstitution)
 // PCM: do { x ++ ; } while ( 0 ) is covered by DO_NOT_SWALLOW_SEMICOLON (kExpansion) DO_NOT_SWALLOW_SEMICOLON (kExpansion)
 // PCM: x is covered by x (kArgument) x (kArgument) X (kParameterSubstitution)
+// PCM: 1 is covered by 1 (kArgument) 1 (kArgument) __VA_ARGS__ (kParameterSubstitution) COMMAS (kExpansion) COMMAS (kExpansion)
+// PCM: 1 , 2 is covered by __VA_ARGS__ (kParameterSubstitution) COMMAS (kExpansion) COMMAS (kExpansion)
+// PCM: 1 is covered by 1 (kArgument) 1 (kArgument)
+// PCM: 2 is covered by 2 (kArgument) 2 (kArgument)
+// PCM: 1 is covered by VA_OPT_TEST (kExpansion) VA_OPT_TEST (kExpansion)
+// PCM: 1 , 1 , 2 , 3 is covered by VA_OPT_TEST (kExpansion) VA_OPT_TEST (kExpansion)
+// PCM: 1 is covered by 1 (kArgument) 1 (kArgument)
+// PCM: 2 is covered by 2 (kArgument) 2 (kArgument)
+// PCM: 3 is covered by 3 (kArgument) 3 (kArgument)
+// PCM: "string" is covered by # (kStringify) STRINGIFY (kExpansion) STRINGIFY (kExpansion)
+// PCM: "one" , "two" is covered by STRINGIFY_SEP_COMMAS (kExpansion) STRINGIFY_SEP_COMMAS (kExpansion)
+// PCM: "one" is covered by # (kStringify)
+// PCM: "two" is covered by # (kStringify)
+// PCM: 1234 is covered by ## (kConcatenate) PASTE (kExpansion) PASTE (kExpansion)
 
 // PAPS: 0 + 1 is covered by the following expansions:
 // PAPS: ADD
@@ -68,32 +209,46 @@
 // PAPS: Aligned parameters:
 // PAPS:   X (expected 1, actual 1):
 // PAPS:     x
+// PAPS: 1 is covered by the following expansions:
+// PAPS: COMMAS
+// PAPS: Aligned parameters:
+// PAPS:   <a nameless parameter> (expected 1, actual 1):
+// PAPS:     1
+// PAPS: 1 , 2 is covered by the following expansions:
+// PAPS: COMMAS
+// PAPS: Aligned parameters:
+// PAPS:   <a nameless parameter> (expected 1, actual 1):
+// PAPS:     1 , 2
+// PAPS: 1 is covered by the following expansions:
+// PAPS: VA_OPT_TEST
+// PAPS: Aligned parameters:
+// PAPS:   <a nameless parameter> (expected 1, actual 0):
+// PAPS: 1 , 1 , 2 , 3 is covered by the following expansions:
+// PAPS: VA_OPT_TEST
+// PAPS: Aligned parameters:
+// PAPS:   <a nameless parameter> (expected 1, actual 0):
+// PAPS: "string" is covered by the following expansions:
+// PAPS: STRINGIFY
+// PAPS: Aligned parameters:
+// PAPS:   A (expected 0, actual 0):
+// PAPS: "one" , "two" is covered by the following expansions:
+// PAPS: STRINGIFY_SEP_COMMAS
+// PAPS: Aligned parameters:
+// PAPS:   A (expected 0, actual 0):
+// PAPS:   B (expected 0, actual 0):
+// PAPS: 1234 is covered by the following expansions:
+// PAPS: PASTE
+// PAPS: Aligned parameters:
+// PAPS:   A (expected 1, actual 0):
+// PAPS:   B (expected 1, actual 0):
+// PAPS:   C (expected 1, actual 0):
+// PAPS:   D (expected 1, actual 0):
 
 // Simple expression function-like macros
 #define ADD(X, Y) X + Y
 
-// PLCSD: ADD covers 0 + 1
-// PLCM: 0 + 1 is covered by ADD at the lowest level
-// PLCM: 0 is covered by X at the lowest level
-// PLCM: 0 is covered by argument of parent macro expansion of macro definition ADD argument number 0 X
-// PLCM: 1 is covered by Y at the lowest level
-// PLCM: 1 is covered by argument of parent macro expansion of macro definition ADD argument number 1 Y
-// PLCMA: 0 is contained in argument of parent macro expansion of macro definition ADD argument number 0 X
-// PLCMA: 1 is contained in argument of parent macro expansion of macro definition ADD argument number 1 Y
-// PHCS: 0 + 1 is contained in ADD at the highest level
-// PHCS: 0 is contained in ADD at the highest level
-// PHCS: 1 is contained in ADD at the highest level
 int one = ADD(0, 1);
 
-// PLCSD: ADD covers nothing
-// PLCM: 2 is covered by X at the lowest level
-// PLCM: 2 is covered by argument of parent macro expansion of macro definition ADD argument number 0 X
-// PLCM: 3 is covered by Y at the lowest level
-// PLCM: 3 is covered by argument of parent macro expansion of macro definition ADD argument number 1 Y
-// PLCMA: 2 is contained in argument of parent macro expansion of macro definition ADD argument number 0 X
-// PLCMA: 3 is contained in argument of parent macro expansion of macro definition ADD argument number 1 Y
-// PHCS: 2 is contained in ADD at the highest level
-// PHCS: 3 is contained in ADD at the highest level
 int seven = 2 * ADD(2, 3);
 
 #define FIZZ_AND(A) \
@@ -101,56 +256,12 @@ int seven = 2 * ADD(2, 3);
   "and" A
 #define BUZZ "BUZZ"
 
-// PLCSD: FIZZ_AND covers "FIZZ" "and" "BUZZ"
-// PLCM: "FIZZ" "and" "BUZZ" is covered by FIZZ_AND at the lowest level
-// PHCS: "FIZZ" "and" "BUZZ" is contained in FIZZ_AND at the highest level
 const char bacon_and_eggs[] = FIZZ_AND(BUZZ);
 
 // Function-like macros that accept other macros as arguments
 #define MUL(X, Y) X * Y
-// PLCSD: ADD covers 1 * 2 + 3 * 4
-// PLCM: 1 * 2 + 3 * 4 is covered by ADD at the lowest level
-// PLCM: 1 * 2 is covered by MUL at the lowest level
-// PLCM: 1 * 2 is covered by argument of parent macro expansion of macro definition ADD argument number 0 X
-// PLCM: 1 is covered by X at the lowest level
-// PLCM: 1 is covered by argument of parent macro expansion of macro definition MUL argument number 0 X
-// PLCM: 2 is covered by Y at the lowest level
-// PLCM: 2 is covered by argument of parent macro expansion of macro definition MUL argument number 1 Y
-// PLCM: 3 * 4 is covered by MUL at the lowest level
-// PLCM: 3 * 4 is covered by argument of parent macro expansion of macro definition ADD argument number 1 Y
-// PLCM: 3 is covered by X at the lowest level
-// PLCM: 3 is covered by argument of parent macro expansion of macro definition MUL argument number 0 X
-// PLCM: 4 is covered by Y at the lowest level
-// PLCM: 4 is covered by argument of parent macro expansion of macro definition MUL argument number 1 Y
-// PLCMA: 1 * 2 is contained in argument of parent macro expansion of macro definition ADD argument number 0 X
-// PLCMA: 1 is contained in argument of parent macro expansion of macro definition MUL argument number 0 X
-// PLCMA: 2 is contained in argument of parent macro expansion of macro
-// definition MUL argument number 1 Y
-// PLCMA: 3 * 4 is contained in argument of parent macro expansion of macro definition ADD argument number 1 Y
-// PLCMA: 3 is contained in argument of parent macro expansion of macro definition MUL argument number 0 X
-// PLCMA: 4 is contained in argument of parent macro expansion of macro definition MUL argument number 1 Y
-// PHCS: 1 * 2 + 3 * 4 is contained in ADD at the highest level
-// PHCS: 1 * 2 is contained in ADD at the highest level
-// PHCS: 1 is contained in ADD at the highest level
-// PHCS: 2 is contained in ADD at the highest level
-// PHCS: 3 * 4 is contained in ADD at the highest level
-// PHCS: 3 is contained in ADD at the highest level
-// PHCS: 4 is contained in ADD at the highest level
 int fourteen = ADD(MUL(1, 2), MUL(3, 4));
 
-// PLCSD: STRANGE covers 1 + 2 + 3
-// PLCM: 1 + 2 + 3 is covered by STRANGE at the lowest level
-// PLCM: 2 is covered by X at the lowest level
-// PLCM: 2 is covered by argument of parent macro expansion of macro definition ADD argument number 0 X
-// PLCM: 3 is covered by Y at the lowest level
-// PLCM: 3 is covered by argument of parent macro expansion of macro definition ADD argument number 1 Y
-// PLCMA: 2 is contained in argument of parent macro expansion of macro definition ADD argument number 0 X
-// PLCMA: 3 is contained in argument of parent macro expansion of macro definition ADD argument number 1 Y
-// PHCS: 1 + 2 + 3 is contained in STRANGE at the highest level
-// PHCS: 1 + 2 is contained in STRANGE at the highest level
-// PHCS: 1 is contained in STRANGE at the highest level
-// PHCS: 2 is contained in STRANGE at the highest level
-// PHCS: 3 is contained in STRANGE at the highest level
 #define STRANGE(A) 1 + A(2
 int strange = STRANGE(ADD), 3);
 
@@ -166,13 +277,10 @@ int strange = STRANGE(ADD), 3);
 #define DECLARE_FUNC_PTR_GENERIC_h(a) a (*UNIQUE_NAME(n_))()
 
 
-// PLCSD: DECLARE_GENERIC_FUNC_f covers int l_UNIQUE ( )
 DECLARE_GENERIC_FUNC_f(int);
 
-// PLCSD: DECLARE_GENERIC_FUNC_g covers char m_UNIQUE ( void )
 DECLARE_GENERIC_FUNC_g(char, void);
 
-// PLCSD: DECLARE_FUNC_PTR_GENERIC_h covers int * ( * n_UNIQUE ) ( )
 DECLARE_FUNC_PTR_GENERIC_h(int *);
 
 
@@ -183,19 +291,37 @@ DECLARE_FUNC_PTR_GENERIC_h(int *);
   } while (0)
 
 
+
 int main(int argc, char const *argv[]) {
   int x;
-  // PLCSD: DO_NOT_SWALLOW_SEMICOLON covers do { x ++ ; } while ( 0 )
-  // PLCM: do { x ++ ; } while ( 0 ) is covered by DO_NOT_SWALLOW_SEMICOLON at the lowest level
-  // PLCM: x is covered by X at the lowest level
-  // PLCM: x is covered by argument of parent macro expansion of macro definition DO_NOT_SWALLOW_SEMICOLON argument number 0 X
-  // PLCMA: x is contained in argument of parent macro expansion of macro definition DO_NOT_SWALLOW_SEMICOLON argument number 0 X
-  // PHCS: do { x ++ ; } while ( 0 ) is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
-  // PHCS: { x ++ ; } is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
-  // PHCS: x ++ is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
-  // PHCS: x is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
-  // PHCS: 0 is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
   DO_NOT_SWALLOW_SEMICOLON(x);
+
+
+  // Variadic macros
+  
+  #define COMMAS(...) __VA_ARGS__
+  COMMAS(1);
+  COMMAS(1, 2);
+
+  #define VA_OPT_TEST(...) 1 __VA_OPT__(,) __VA_ARGS__
+  VA_OPT_TEST();
+  VA_OPT_TEST(1, 2, 3);
+
+
+  // Stringification
+
+  #define STRINGIFY(A) #A
+  STRINGIFY(string);
+
+  #define STRINGIFY_SEP_COMMAS(A, B) #A, #B
+
+  // Token-pasting
+
+  STRINGIFY_SEP_COMMAS(one, two);
+  #define PASTE(A, B, C, D) A ## B ## C ## D
+  PASTE(1, 2, 3, 4);
+
+
 
   return 0;
 }

--- a/test/MacroCoveringAndContainingTests/object_like.c
+++ b/test/MacroCoveringAndContainingTests/object_like.c
@@ -4,6 +4,92 @@
 // RUN: print-lowest-covering-macro %s | FileCheck %s -check-prefix=PLCM
 // RUN: print-covering-macros %s | FileCheck %s -check-prefix=PCM
 
+// PHCS: 1 is contained in ONE at the highest level
+// PHCS: 'A' is contained in A at the highest level
+// PHCS: - 1 is contained in NEG_ONE at the highest level
+// PHCS: 1 is contained in NEG_ONE at the highest level
+// PHCS: 1 + 1 is contained in MID at the highest level
+// PHCS: 1 is contained in MID at the highest level
+// PHCS: 1 is contained in MID at the highest level
+// PHCS: 2 + 1 + 1 is contained in OUTER at the highest level
+// PHCS: 2 + 1 is contained in OUTER at the highest level
+// PHCS: 2 is contained in OUTER at the highest level
+// PHCS: 1 is contained in OUTER at the highest level
+// PHCS: 1 is contained in OUTER at the highest level
+// PHCS: ( 2 + ( 1 + 1 ) ) is contained in OUTER_SAFE at the highest level
+// PHCS: 2 + ( 1 + 1 ) is contained in OUTER_SAFE at the highest level
+// PHCS: 2 is contained in OUTER_SAFE at the highest level
+// PHCS: ( 1 + 1 ) is contained in OUTER_SAFE at the highest level
+// PHCS: 1 + 1 is contained in OUTER_SAFE at the highest level
+// PHCS: 1 is contained in OUTER_SAFE at the highest level
+// PHCS: 1 is contained in OUTER_SAFE at the highest level
+// PHCS: 1 is contained in ONE_PLUS_ONE at the highest level
+// PHCS: 1 is contained in ONE_PLUS_ONE at the highest level
+// PHCS: 1 is contained in ONE_PLUS at the highest level
+// PHCS: weird is contained in STRANGE at the highest level
+// PHCS: do { } while ( 0 ) is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
+// PHCS: { } is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
+// PHCS: 0 is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
+// PHCS: do { } while ( 0 ) is contained in SWALLOW_SEMICOLON at the highest level
+// PHCS: { } is contained in SWALLOW_SEMICOLON at the highest level
+// PHCS: 0 is contained in SWALLOW_SEMICOLON at the highest level
+// PHCS: 1 is contained in ONE_SEMI at the highest level
+// PHCS: return 0 is contained in EXIT_SUCCESS at the highest level
+// PHCS: 0 is contained in EXIT_SUCCESS at the highest level
+// PHCS: 1 is contained in __STDC__ at the highest level
+// PHCS: "object_like.c" is contained in __FILE_NAME__ at the highest level
+
+// PLCSD: ONE covers 1
+// PLCSD: A covers 'A'
+// PLCSD: NEG_ONE covers - 1
+// PLCSD: NOTHING covers nothing
+// PLCSD: MID covers 1 + 1
+// PLCSD: INNER covers 1
+// PLCSD: INNER covers 1
+// PLCSD: OUTER covers 2 + 1 + 1
+// PLCSD: MID covers nothing
+// PLCSD: INNER covers 1
+// PLCSD: INNER covers 1
+// PLCSD: OUTER_SAFE covers ( 2 + ( 1 + 1 ) )
+// PLCSD: MID_SAFE covers ( 1 + 1 )
+// PLCSD: INNER covers 1
+// PLCSD: INNER covers 1
+// PLCSD: ONE_PLUS_ONE covers nothing
+// PLCSD: ONE_PLUS covers nothing
+// PLCSD: DECLARE_INT_i covers int i ;
+// PLCSD: DECLARE_INT_PTR_j covers int * j ;
+// PLCSD: DECLARE_FUNC_k covers int k ( ) ;
+// PLCSD: DECLARE_FUNC_l covers int l ( ) ;
+// PLCSD: P covers nothing
+// PLCSD: INT covers nothing
+// PLCSD: STRANGE covers nothing
+// PLCSD: DO_NOT_SWALLOW_SEMICOLON covers do { } while ( 0 )
+// PLCSD: SWALLOW_SEMICOLON covers do { } while ( 0 )
+// PLCSD: ONE_SEMI covers 1
+// PLCSD: EXIT_SUCCESS covers return 0
+// PLCSD: __STDC__ covers 1
+// PLCSD: __FILE_NAME__ covers "object_like.c"
+
+// PLCM: 1 is covered by ONE at the lowest level
+// PLCM: 'A' is covered by A at the lowest level
+// PLCM: - 1 is covered by NEG_ONE at the lowest level
+// PLCM: 1 + 1 is covered by MID at the lowest level
+// PLCM: 1 is covered by INNER at the lowest level
+// PLCM: 1 is covered by INNER at the lowest level
+// PLCM: 2 + 1 + 1 is covered by OUTER at the lowest level
+// PLCM: 1 is covered by INNER at the lowest level
+// PLCM: 1 is covered by INNER at the lowest level
+// PLCM: ( 2 + ( 1 + 1 ) ) is covered by OUTER_SAFE at the lowest level
+// PLCM: ( 1 + 1 ) is covered by MID_SAFE at the lowest level
+// PLCM: 1 is covered by INNER at the lowest level
+// PLCM: 1 is covered by INNER at the lowest level
+// PLCM: do { } while ( 0 ) is covered by DO_NOT_SWALLOW_SEMICOLON at the lowest level
+// PLCM: do { } while ( 0 ) is covered by SWALLOW_SEMICOLON at the lowest level
+// PLCM: 1 is covered by ONE_SEMI at the lowest level
+// PLCM: return 0 is covered by EXIT_SUCCESS at the lowest level
+// PLCM: 1 is covered by __STDC__ at the lowest level
+// PLCM: "object_like.c" is covered by __FILE_NAME__ at the lowest level
+
 // PCM: 1 is covered by ONE (kExpansion)
 // PCM: 'A' is covered by A (kExpansion)
 // PCM: - 1 is covered by NEG_ONE (kExpansion)
@@ -21,117 +107,61 @@
 // PCM: do { } while ( 0 ) is covered by SWALLOW_SEMICOLON (kExpansion)
 // PCM: 1 is covered by ONE_SEMI (kExpansion)
 // PCM: return 0 is covered by EXIT_SUCCESS (kExpansion)
+// PCM: 1 is covered by __STDC__ (kExpansion)
+// PCM: "object_like.c" is covered by __FILE_NAME__ (kExpansion)
 
 // Simple expression macros
 #define ONE 1
-// PLCSD: ONE covers 1
-// PHCS: 1 is contained in ONE at the highest level
-// PLCM: 1 is covered by ONE at the lowest level
 int one = ONE;
 
 #define A 'A'
-// PLCSD: A covers 'A'
-// PHCS: 'A' is contained in A at the highest level
-// PLCM: 'A' is covered by A at the lowest level
 char a = A;
 
 #define NEG_ONE -1
-// PLCSD: NEG_ONE covers - 1
-// PHCS: - 1 is contained in NEG_ONE
-// PHCS: 1 is contained in NEG_ONE
-// PLCM: - 1 is covered by NEG_ONE at the lowest level
 int negative_one = NEG_ONE;
 
 #define NOTHING
-// PLCSD: NOTHING covers nothing
 int nothing = NOTHING 0;
 
 // Nested object-like macros
 #define INNER 1
 #define MID INNER + INNER
 #define OUTER 2 + MID
-// PLCSD: MID covers 1 + 1
-// PLCSD: INNER covers 1
-// PLCSD: INNER covers 1
-// PLCM: 1 + 1 is covered by MID at the lowest level
-// PLCM: 1 is covered by INNER at the lowest level
-// PLCM: 1 is covered by INNER at the lowest level
-// PLCM: 2 + 1 + 1 is covered by OUTER at the lowest level
-// PLCM: 1 is covered by INNER at the lowest level
-// PLCM: 1 is covered by INNER at the lowest level
-// PHCS: 1 + 1 is contained in MID
-// PHCS: 1 is contained in MID 
-// PHCS: 1 is contained in MID
 int mid = MID;
-// PLCSD: OUTER covers 2 + 1 + 1
 // MID covers nothing because of operator precedence issues
-// PLCSD: MID covers nothing
-// PLCSD: INNER covers 1
-// PLCSD: INNER covers 1
-// PHCS: 2 + 1 + 1 is contained in OUTER at the highest level
-// PHCS: 2 + 1 is contained in OUTER at the highest level
-// PHCS: 2 is contained in OUTER at the highest level
-// PHCS: 1 is contained in OUTER at the highest level
-// PHCS: 1 is contained in OUTER at the highest level
 int outer_1 = OUTER;
 
 #define MID_SAFE (INNER + INNER)
 #define OUTER_SAFE (2 + MID_SAFE)
-// PLCSD: OUTER_SAFE covers ( 2 + ( 1 + 1 ) )
-// PLCSD: MID_SAFE covers ( 1 + 1 )
-// PLCSD: INNER covers 1
-// PLCSD: INNER covers 1
-// PLCM: ( 2 + ( 1 + 1 ) ) is covered by OUTER_SAFE at the lowest level
-// PLCM: ( 1 + 1 ) is covered by MID_SAFE at the lowest level
-// PLCM: 1 is covered by INNER at the lowest level
-// PLCM: 1 is covered by INNER at the lowest level
-// PHCS: ( 2 + ( 1 + 1 ) ) is contained in OUTER_SAFE at the highest level
-// PHCS: 2 + ( 1 + 1 ) is contained in OUTER_SAFE at the highest level
-// PHCS: 2 is contained in OUTER_SAFE at the highest level
-// PHCS: ( 1 + 1 ) is contained in OUTER_SAFE at the highest level
-// PHCS: 1 + 1 is contained in OUTER_SAFE at the highest level
-// PHCS: 1 is contained in OUTER_SAFE at the highest level
-// PHCS: 1 is contained in OUTER_SAFE at the highest level
 int outer_2 = OUTER_SAFE;
 
 // Macros that cover nothing because of operator precedence issues
 #define ONE_PLUS_ONE 1 + 1
-// PLCSD: ONE_PLUS_ONE covers nothing
 
 int three = 2 * ONE_PLUS_ONE;
-// PHCS: 1 is contained in ONE_PLUS_ONE at the highest level
-// PHCS: 1 is contained in ONE_PLUS_ONE at the highest level
 #define ONE_PLUS 1 +
-// PLCSD: ONE_PLUS covers nothing
-// PHCS: 1 is contained in ONE_PLUS at the highest level
 int two = ONE_PLUS 1;
 
 // Simple declaration macros
 #define DECLARE_INT_i int i
-// PLCSD: DECLARE_INT_i covers int i
 DECLARE_INT_i;
 
 #define DECLARE_INT_PTR_j int *j
-// PLCSD: DECLARE_INT_PTR_j covers int * j
 DECLARE_INT_PTR_j;
 
 #define DECLARE_FUNC_k int k()
-// PLCSD: DECLARE_FUNC_k covers int k ( )
 DECLARE_FUNC_k;
 
 #define DECLARE_FUNC_l int l();
 
 // NOTE: Our heuristic should enable us to find this declaration
-// PLCSD: DECLARE_FUNC_l covers int l ( ) ;
 DECLARE_FUNC_l
 
 #define P p
-// PLCSD: P covers nothing
 int P = 1;
 
 /* Simple type macros*/
 #define INT int
-// PLCSD: INT covers nothing
 INT int_ = 0;
 
 /* Macros with misnested parentheses */
@@ -142,8 +172,6 @@ int weird() {
 }
 
 int foo(int argc, char const *argv[]) {
-  // PLCSD: STRANGE covers nothing
-  // PHCS: weird is contained in STRANGE at the highest level
   STRANGE);
 
 // Non-Expr Stmt macros
@@ -155,39 +183,30 @@ int foo(int argc, char const *argv[]) {
   do { \
   } while (0);
 
-  // PLCSD: DO_NOT_SWALLOW_SEMICOLON covers do { } while ( 0 )
-  // PHCS: do { } while ( 0 ) is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
-  // PHCS: { } is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
-  // PHCS: 0 is contained in DO_NOT_SWALLOW_SEMICOLON at the highest level
-  // PLCM: do { } while ( 0 ) is covered by DO_NOT_SWALLOW_SEMICOLON at the lowest level
   DO_NOT_SWALLOW_SEMICOLON;
 
   // Note: Even though the expansion includes the semicolon, our heuristics
   // should return the do-while statement, which does not include the semicolon
-  // PLCSD: SWALLOW_SEMICOLON covers do { } while ( 0 )
-  // PLCM: do { } while ( 0 ) is covered by SWALLOW_SEMICOLON at the lowest level
-  // PHCS: do { } while ( 0 ) is contained in SWALLOW_SEMICOLON at the highest level
-  // PHCS: { } is contained in SWALLOW_SEMICOLON at the highest level
-  // PHCS: 0 is contained in SWALLOW_SEMICOLON at the highest level
   SWALLOW_SEMICOLON
 
 #define ONE_SEMI 1;
 
-  // PLCSD: ONE_SEMI covers 1
-  // PHCS: 1 is contained in ONE_SEMI at the highest level
-  // PLCM: 1 is covered by ONE_SEMI at the lowest level
   ONE_SEMI
 
 #define EXIT_SUCCESS return 0;
 
-  // PLCSD: EXIT_SUCCESS covers return 0
-  // PLCM: return 0 is covered by EXIT_SUCCESS at the lowest level
-  // PHCS: return 0 is contained in EXIT_SUCCESS at the highest level
-  // PHCS: 0 is contained in EXIT_SUCCESS at the highest level
   EXIT_SUCCESS
 }
 
 int main(int argc, char const *argv[])
 {
+  // Predefined object-like macro tests NOTE(bpappas):
+
+  // We don't have automated tests for predefined outputs with dynamic output,
+  // e.g. __DATE__ and __TIME__, but they can easily be tested manually.
+  
+  __STDC__;
+  __FILE_NAME__;
+
   return 0;
 }


### PR DESCRIPTION
- Adds a new method to the `MacroSubstitution` class for getting the names of substituted macros.
- Uses this new method to correct the output of some of the binaries for printing covering macros.
- Silences a small warning in the PrintMacroGraph binary about an implicit cast from a string value to a Boolean value.