### PR TITLE
Enable `pasta::AST` to adopt `clang::Attr`s

### DIFF
--- a/include/pasta/AST/AST.h
+++ b/include/pasta/AST/AST.h
@@ -28,6 +28,7 @@ class SourceLocation;
 namespace pasta {
 
 class ASTImpl;
+class Attr;
 class CompileJob;
 class Compiler;
 class Decl;
@@ -85,6 +86,7 @@ class AST {
 
 #ifndef PASTA_IN_BOOTSTRAP
   Token Adopt(const clang::SourceLocation &loc) const;
+  Attr Adopt(const clang::Attr *attr) const;
   Decl Adopt(const clang::Decl *decl) const;
   Stmt Adopt(const clang::Stmt *stmt) const;
   Type Adopt(const clang::Type *type, uint32_t qual = 0u) const;

--- a/lib/AST/AST.cpp
+++ b/lib/AST/AST.cpp
@@ -243,6 +243,10 @@ Token AST::Adopt(const clang::SourceLocation &loc) const {
   return impl->TokenAt(loc);
 }
 
+Attr AST::Adopt(const clang::Attr *attr) const {
+  return Attr(impl, attr);
+}
+
 Decl AST::Adopt(const clang::Decl *decl) const {
   return Decl(impl, decl);
 }


### PR DESCRIPTION
Add a method to `pasta::AST` for adopting `clang::Attr`s