### PR TITLE
Generalize aligned substitutions

### DIFF
--- a/bin/BootstrapTypes/GenerateStmtH.cpp
+++ b/bin/BootstrapTypes/GenerateStmtH.cpp
@@ -95,7 +95,7 @@ void GenerateStmtH(void) {
     if (name_ref == "Stmt") {
       os << "  friend class TokenContext;\n"
          << "  static std::optional<::pasta::Stmt> From(const TokenContext &);\n"
-         << "  std::vector<::pasta::MacroSubstitution> AlignedSubstitutions(void) const noexcept;\n"
+         << "  std::vector<::pasta::MacroSubstitution> AlignedSubstitutions(bool heuristic = true) const noexcept;\n"
          << "  bool AlignsWith(::pasta::Macro &) const noexcept;\n";
     }
 

--- a/include/pasta/AST/Stmt.h
+++ b/include/pasta/AST/Stmt.h
@@ -296,7 +296,7 @@ class Stmt {
   PASTA_DECLARE_DEFAULT_CONSTRUCTORS(Stmt)
   friend class TokenContext;
   static std::optional<::pasta::Stmt> From(const TokenContext &);
-  std::vector<::pasta::MacroSubstitution> AlignedSubstitutions(void) const noexcept;
+  std::vector<::pasta::MacroSubstitution> AlignedSubstitutions(bool heuristic = true) const noexcept;
   bool AlignsWith(::pasta::Macro &) const noexcept;
   PASTA_DECLARE_DERIVED_OPERATORS(Stmt, AbstractConditionalOperator)
   PASTA_DECLARE_DERIVED_OPERATORS(Stmt, AddrLabelExpr)

--- a/include/pasta/AST/Token.h
+++ b/include/pasta/AST/Token.h
@@ -41,6 +41,7 @@ class Designator;
 class FileToken;
 class FileTokenRange;
 class Macro;
+class MacroSubstitution;
 class MacroToken;
 class PrintedTokenRangeImpl;
 class TemplateArgument;
@@ -398,6 +399,12 @@ class TokenRange {
 
   // Unsafe indexed access into the token range.
   Token operator[](size_t index) const;
+
+  // Returns the list of macros that align with this token range, in the order
+  // of most-nested to least. The optional heuristic determines whether or not
+  // to try and match macro expansions that contain semicolons.
+  std::vector<MacroSubstitution>
+  AlignedSubstitutions(bool heuristic) noexcept;
 
   // Is this token range valid?
   inline operator bool(void) const noexcept {

--- a/lib/AST/StmtManual.cpp
+++ b/lib/AST/StmtManual.cpp
@@ -14,6 +14,7 @@
 
 #include "AST.h"
 #include "Builder.h"
+#include "Macro.h"
 
 #include <algorithm>
 #include <vector>
@@ -23,147 +24,10 @@ namespace pasta {
 #ifndef PASTA_IN_BOOTSTRAP
 
 // Returns a list of macros that align with this Stmt, if any.
-std::vector<MacroSubstitution> Stmt::AlignedSubstitutions(void) const noexcept {
-  // The big idea is that we want to find the all macros that aligns in the
-  // front and back with the given statement. The catch is that a macro might
-  // contain nested substitutions, e.g. argument expansions or nested
-  // expansions. Also, we should match statements which were expanded from
-  // macros containing a trailing semicolon.
-
-  // Algorithm:
-  // 1. Walk the first token's derived token chain from final expansion token to
-  //    the initial macro use token.
-  // 2. Walk up this token's expansion tree. If we encounter a non-substitution
-  //    macro, stop traversing the expansion tree and ascend the derivation
-  //    tree. If we encounter a macro substitution, check that this token is the
-  //    first in the macro's replacement list. If so, the continue to the next
-  //    step; otherwise keep ascending the token derivation tree. There is also
-  //    an edge-case to check for: If the current token is the first token in
-  //    the macro's intermediate expansion children, then we must immediately
-  //    return early, because otherwise we might erroneously match a macro with
-  //    one of its arguments if they share a derivation tree. For example:
-  //      #define ADD(X, Y)
-  //      int x = ADD(ADD(1, 2), 3)
-  //    This check prevents 1 + 2 + 3 from aligning with both invocations of
-  //    ADD(), and ensures that it will only align with the top-level
-  //    invocation.
-  // 3. Walk up the last token's derived token chain from the initial macro use
-  //    token to the final macro expansion token.
-  // 4. Walk up the last derived token's derivation tree. If the last token is
-  //    ever derived from the same token that the first token is derived from,
-  //    then exit this iteration early to avoid false positives. If we encounter
-  //    a macro substitution, check that this token is the last in the macro's
-  //    replacement list. Follow similar logic as when checking for
-  //    front-alignment. This also where we incorporate the heuristic for
-  //    aligning macros that contain semicolons. If this check succeeds, then we
-  //    have found an aligned invocation.
-  // 5. The algorithm ends once we have walked the first token's entire
-  //    derivation chain.
-
-  std::vector<MacroSubstitution> result;
-  Token b_tok = BeginToken();
-  if (!b_tok) {
-    return result;
-  }
-
-  auto b_tok_deriv_chain = b_tok.DerivationChain();
-
-  Token e_tok = EndToken();
-  auto e_tok_deriv_chain = e_tok.DerivationChain();
-
-  auto tok_after_e_tok = e_tok.NextFinalExpansionOrFileToken();
-  bool semi = tok_after_e_tok && tok_after_e_tok->Kind() == TokenKind::kSemi;
-
-  for (auto b_deriv : b_tok_deriv_chain) {
-    std::optional<Macro> b_macro = b_deriv.MacroLocation();
-    if (!b_macro) {
-      continue;
-    }
-
-    for (auto b_parent = b_macro->Parent(); b_parent;
-         b_macro = *b_parent, b_parent = b_parent->Parent()) {
-      auto b_parent_sub = MacroSubstitution::From(*b_parent);
-      if (!b_parent_sub) {
-        break;
-      }
-
-      // Here is the first edge-case. We only allow a macro token to be the
-      // first child in its parent's intermediate replacement list if the macro
-      // token is a parameter substitution.
-      if (auto b_parent_exp = MacroExpansion::From(*b_parent_sub)) {
-        MacroRange body = b_parent_exp->IntermediateChildren();
-        bool is_psub = b_macro->Kind() == MacroKind::kParameterSubstitution;
-        if (b_macro == body.Front() && !is_psub) {
-          return result;
-        }
-      }
-
-      auto b_parent_replacement = b_parent_sub->ReplacementChildren();
-      bool front_aligned = (b_macro == b_parent_replacement.Front());
-      if (!front_aligned) {
-        break;
-      }
-
-      for (auto e_deriv : e_tok_deriv_chain) {
-        // Here's the rub: If the begin and end tokens ever converge to the same
-        // derived token, then their derivation trees have started mixing. This
-        // can happen if two separate arguments of the macro are invocations of
-        // the same macro definition. To see an example, print the macro graph
-        // of the following invocation code snippet:
-        //
-        // #define ONE 1
-        // #define ADD(x, y) x + y
-        // ADD(ONE, ONE)
-        //
-        // This isn't a problem if the begin and end tokens were the same tokens
-        // to begin with (then of course their derivation trees would be the
-        // same). Otherwise we should exit early, since this mixing might cause
-        // us to return a false positive.
-
-        // NOTE(bpappas): I am fairly certain that returning here will prevent
-        // false positives, but I am not sure if it will create false negatives.
-        if (b_deriv == e_deriv && b_tok != e_tok) {
-          break;
-        }
-
-        std::optional<Macro> e_macro = e_deriv.MacroLocation();
-        if (!e_macro) {
-          continue;
-        }
-
-        for (auto e_parent = e_macro->Parent(); e_parent;
-             e_macro = *e_parent, e_parent = e_parent->Parent()) {
-          auto e_parent_sub = MacroSubstitution::From(*e_parent);
-          if (!e_parent_sub) {
-            break;
-          }
-
-          if (auto e_parent_exp = MacroExpansion::From(*e_parent_sub)) {
-            MacroRange body = e_parent_exp->IntermediateChildren();
-            bool is_psub = e_macro->Kind() == MacroKind::kParameterSubstitution;
-            if (e_macro == body.Back() && !is_psub) {
-              break;
-            }
-          }
-
-          auto psub_last_tok = e_parent_sub->LastFullySubstitutedToken();
-          auto e_parent_replacement = e_parent_sub->ReplacementChildren();
-          bool back_aligned = ((e_macro == e_parent_replacement.Back()) ||
-                               (semi && tok_after_e_tok == psub_last_tok));
-
-          if (!back_aligned) {
-            break;
-          }
-
-          if (b_parent == e_parent) {
-            result.push_back(*b_parent_sub);
-          }
-        }
-      }
-    }
-  }
-
-  return result;
+std::vector<MacroSubstitution> Stmt::AlignedSubstitutions(
+  bool heuristic /* = true */) const noexcept {
+  auto tokens = Tokens();
+  return tokens.AlignedSubstitutions(heuristic);
 }
 
 bool Stmt::AlignsWith(Macro &macro) const noexcept {

--- a/lib/AST/Token.cpp
+++ b/lib/AST/Token.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2021 Trail of Bits, Inc.
  */
 
+#include "Macro.h"
 #include "Token.h"
 
 #include <cassert>
@@ -775,6 +776,153 @@ std::optional<Token> TokenRange::At(size_t index) const noexcept {
 // Unsafe indexed access into the token range.
 Token TokenRange::operator[](size_t index) const {
   return Token(ast, &(first[index]));
+}
+
+std::vector<MacroSubstitution>
+TokenRange::AlignedSubstitutions(bool heuristic) noexcept {
+  // The big idea is that we want to find the all macros that aligns in the
+  // front and back with the given statement. The catch is that a macro might
+  // contain nested substitutions, e.g. argument expansions or nested
+  // expansions. Also, we should match statements which were expanded from
+  // macros containing a trailing semicolon.
+
+  // Algorithm:
+  // 1. Walk the first token's derived token chain from final expansion token to
+  //    the initial macro use token.
+  // 2. Walk up this token's expansion tree. If we encounter a non-substitution
+  //    macro, stop traversing the expansion tree and ascend the derivation
+  //    tree. If we encounter a macro substitution, check that this token is the
+  //    first in the macro's replacement list. If so, the continue to the next
+  //    step; otherwise keep ascending the token derivation tree. There is also
+  //    an edge-case to check for: If the current token is the first token in
+  //    the macro's intermediate expansion children, then we must immediately
+  //    return early, because otherwise we might erroneously match a macro with
+  //    one of its arguments if they share a derivation tree. For example:
+  //      #define ADD(X, Y)
+  //      int x = ADD(ADD(1, 2), 3)
+  //    This check prevents 1 + 2 + 3 from aligning with both invocations of
+  //    ADD(), and ensures that it will only align with the top-level
+  //    invocation.
+  // 3. Walk up the last token's derived token chain from the initial macro use
+  //    token to the final macro expansion token.
+  // 4. Walk up the last derived token's derivation tree. If the last token is
+  //    ever derived from the same token that the first token is derived from,
+  //    then exit this iteration early to avoid false positives. If we encounter
+  //    a macro substitution, check that this token is the last in the macro's
+  //    replacement list. Follow similar logic as when checking for
+  //    front-alignment. This also where we incorporate the heuristic for
+  //    aligning macros that contain semicolons. If this check succeeds, then we
+  //    have found an aligned invocation.
+  // 5. The algorithm ends once we have walked the first token's entire
+  //    derivation chain.
+  auto b_tok = Front(), e_tok = Back();
+
+  std::vector<MacroSubstitution> result;
+  if (!b_tok || !*b_tok || !e_tok || !*e_tok) {
+    return result;
+  }
+
+  auto b_tok_deriv_chain = b_tok->DerivationChain();
+
+  auto e_tok_deriv_chain = e_tok->DerivationChain();
+
+  // If the heuristic is enabled, keep track of the token that immediately
+  // follows this statement to check if it's a semicolon.
+  auto tok_after_e_tok = (heuristic
+                          ? e_tok->NextFinalExpansionOrFileToken()
+                          : std::nullopt);
+  bool semi = tok_after_e_tok && tok_after_e_tok->Kind() == TokenKind::kSemi;
+
+  for (auto b_deriv : b_tok_deriv_chain) {
+    std::optional<Macro> b_macro = b_deriv.MacroLocation();
+    if (!b_macro) {
+      continue;
+    }
+
+    for (auto b_parent = b_macro->Parent(); b_parent;
+         b_macro = *b_parent, b_parent = b_parent->Parent()) {
+      auto b_parent_sub = MacroSubstitution::From(*b_parent);
+      if (!b_parent_sub) {
+        break;
+      }
+
+      // Here is the first edge-case. We only allow a macro token to be the
+      // first child in its parent's intermediate replacement list if the macro
+      // token is a parameter substitution.
+      if (auto b_parent_exp = MacroExpansion::From(*b_parent_sub)) {
+        MacroRange body = b_parent_exp->IntermediateChildren();
+        bool is_psub = b_macro->Kind() == MacroKind::kParameterSubstitution;
+        if (b_macro == body.Front() && !is_psub) {
+          return result;
+        }
+      }
+
+      auto b_parent_replacement = b_parent_sub->ReplacementChildren();
+      bool front_aligned = (b_macro == b_parent_replacement.Front());
+      if (!front_aligned) {
+        break;
+      }
+
+      for (auto e_deriv : e_tok_deriv_chain) {
+        // Here's the rub: If the begin and end tokens ever converge to the same
+        // derived token, then their derivation trees have started mixing. This
+        // can happen if two separate arguments of the macro are invocations of
+        // the same macro definition. To see an example, print the macro graph
+        // of the following invocation code snippet:
+        //
+        // #define ONE 1
+        // #define ADD(x, y) x + y
+        // ADD(ONE, ONE)
+        //
+        // This isn't a problem if the begin and end tokens were the same tokens
+        // to begin with (then of course their derivation trees would be the
+        // same). Otherwise we should exit early, since this mixing might cause
+        // us to return a false positive.
+
+        // NOTE(bpappas): I am fairly certain that returning here will prevent
+        // false positives, but I am not sure if it will create false negatives.
+        if (b_deriv == e_deriv && b_tok != e_tok) {
+          break;
+        }
+
+        std::optional<Macro> e_macro = e_deriv.MacroLocation();
+        if (!e_macro) {
+          continue;
+        }
+
+        for (auto e_parent = e_macro->Parent(); e_parent;
+             e_macro = *e_parent, e_parent = e_parent->Parent()) {
+          auto e_parent_sub = MacroSubstitution::From(*e_parent);
+          if (!e_parent_sub) {
+            break;
+          }
+
+          if (auto e_parent_exp = MacroExpansion::From(*e_parent_sub)) {
+            MacroRange body = e_parent_exp->IntermediateChildren();
+            bool is_psub = e_macro->Kind() == MacroKind::kParameterSubstitution;
+            if (e_macro == body.Back() && !is_psub) {
+              break;
+            }
+          }
+
+          auto psub_last_tok = e_parent_sub->LastFullySubstitutedToken();
+          auto e_parent_replacement = e_parent_sub->ReplacementChildren();
+          bool back_aligned = ((e_macro == e_parent_replacement.Back()) ||
+                               (semi && tok_after_e_tok == psub_last_tok));
+
+          if (!back_aligned) {
+            break;
+          }
+
+          if (b_parent == e_parent) {
+            result.push_back(*b_parent_sub);
+          }
+        }
+      }
+    }
+  }
+
+  return result;
 }
 
 // Strip off leading whitespace from a token that has been read.


### PR DESCRIPTION
- Generalize the method `Stmt:AlignedSubstitutions()` to be a method of `TokenRange` instead so that a client may easily use to find macros that align with any construct that has a token range.