### PR TITLE
Add `TokenRange::From()` to build token ranges

### DIFF
--- a/include/pasta/AST/Token.h
+++ b/include/pasta/AST/Token.h
@@ -374,6 +374,9 @@ class TokenRange {
     return TokenIterator(ast, after_last);
   }
 
+  // Creates a TokenRange from the given beginning and ending tokens.
+  static TokenRange From(Token begin, Token end);
+
   inline size_t size(void) const noexcept {
     return Size();
   }

--- a/include/pasta/AST/Token.h
+++ b/include/pasta/AST/Token.h
@@ -374,8 +374,10 @@ class TokenRange {
     return TokenIterator(ast, after_last);
   }
 
-  // Creates a TokenRange from the given beginning and ending tokens.
-  static TokenRange From(Token begin, Token end);
+  // Tries to create a TokenRange from the given beginning and ending tokens.
+  // Fails if the tokens don't belong to the same AST, or if the beginning token
+  // comes after the ending token.
+  static std::optional<TokenRange> From(Token begin, Token end);
 
   inline size_t size(void) const noexcept {
     return Size();

--- a/lib/AST/Token.cpp
+++ b/lib/AST/Token.cpp
@@ -745,7 +745,10 @@ ptrdiff_t TokenIterator::operator-(const TokenIterator &that) const noexcept {
   return token.impl - that.token.impl;
 }
 
-TokenRange TokenRange::From(Token begin, Token end) {
+std::optional<TokenRange> TokenRange::From(Token begin, Token end) {
+  if (begin.ast != end.ast || begin > end) {
+    return std::nullopt;
+  }
   return TokenRange(begin.ast, begin.impl, &(end.impl[1]));
 }
 

--- a/lib/AST/Token.cpp
+++ b/lib/AST/Token.cpp
@@ -745,6 +745,10 @@ ptrdiff_t TokenIterator::operator-(const TokenIterator &that) const noexcept {
   return token.impl - that.token.impl;
 }
 
+TokenRange TokenRange::From(Token begin, Token end) {
+  return TokenRange(begin.ast, begin.impl, &(end.impl[1]));
+}
+
 // Number of tokens in this range.
 size_t TokenRange::Size(void) const noexcept {
   return static_cast<size_t>(after_last - first);


### PR DESCRIPTION
Adds a static method to `TokenRange` for building token ranges from arbitrary tokens