### PR TITLE
Pag/track split token: Redefine methods for finding substitutions that align with tokens

### DIFF
--- a/include/pasta/AST/Macro.h
+++ b/include/pasta/AST/Macro.h
@@ -495,7 +495,7 @@ class MacroExpansion final : public MacroSubstitution {
 
   // Maps each of the macro's parameters to a vector of Stmts that their
   // substitutions align with in the given statement.
-  std::map<MacroParameter, std::vector<pasta::Stmt>>
+  std::vector<std::pair<MacroParameter, std::vector<pasta::Stmt>>>
   AlignedParameterSubstitutions(const pasta::Stmt &stmt) const noexcept;
 
   // Maps each of the macro's parameters to the number of times it is used in

--- a/include/pasta/AST/Token.h
+++ b/include/pasta/AST/Token.h
@@ -118,6 +118,12 @@ class Token {
   // operation.
   DerivedToken DerivedLocation(void) const;
 
+  // Returns the list of macro tokens that this token derives from. The result
+  // vector's first element is the most immediate macro token that this token
+  // derives from, and the last element is the root of this token's macro
+  // derivation tree.
+  std::vector<MacroToken> MacroDerivationChain(void) const;
+
   // Location of the token in a file. This will try to track the token back to
   // any file token, so it's really a multi-step process, unlike
   // `DerivedLocation`.
@@ -125,6 +131,9 @@ class Token {
 
   // Location of the token in a macro expansion.
   std::optional<MacroToken> MacroLocation(void) const;
+
+  // Returns the first file token in the AST after this token.
+  std::optional<MacroToken> NextMacroToken(void) const noexcept;
 
   // This token may represent a marker for the location of a macro directive.
   // If so, return that directive.

--- a/lib/AST/Token.cpp
+++ b/lib/AST/Token.cpp
@@ -7,6 +7,8 @@
 
 #include <cassert>
 #include <limits>
+#include <optional>
+#include <variant>
 #include <vector>
 
 #pragma GCC diagnostic push
@@ -678,28 +680,188 @@ bool TokenRange::Contains(const Token &tok) const noexcept {
          tok.offset < after_last;
 }
 
+std::vector<MacroToken> Token::MacroDerivationChain(void) const {
+  std::vector<MacroToken> derivation_chain;
+  auto derived_token = DerivedLocation();
+  if (!std::holds_alternative<MacroToken>(derived_token)) {
+    return derivation_chain;
+  }
+  std::optional<MacroToken> cur = std::get<MacroToken>(derived_token);
+  do {
+    derivation_chain.push_back(*cur);
+    auto deriv_loc = cur->DerivedLocation();
+    cur = std::nullopt;
+    if (std::holds_alternative<MacroToken>(deriv_loc)) {
+      cur = std::get<MacroToken>(deriv_loc);
+    }
+  } while (cur);
+  return derivation_chain;
+}
+
+// Returns the first macro token in the program after this token.
+std::optional<MacroToken> Token::NextMacroToken(void) const noexcept {
+  // NOTE(bpappas): I coied the code for MacroLocation() and added one to
+  // offset, is that enough?
+  auto target_offset = offset + 1; 
+  if (storage->location.size() <= target_offset) {
+    return std::nullopt;
+  }
+  auto bit_loc = storage->location[target_offset];
+  if (IsInvalidOrFileBitPackedLocation(bit_loc)) {
+    return std::nullopt;
+  }
+
+  auto ast = storage->ast;
+  auto &macro_tokens = ast->macro_tokens;
+
+  return MacroToken(
+      std::shared_ptr<ASTImpl>(storage, ast),
+      &(ast->root_macro_node.token_nodes[
+          macro_tokens.macro_token_offset[MacroTokenOffset(bit_loc)]]));
+}
+
 std::vector<MacroSubstitution>
 TokenRange::AlignedSubstitutions(bool heuristic) noexcept {
-  auto maybe_front = Front();
+  // The big idea is that we want to find the all macros that aligns in the
+  // front and back with the given statement. The catch is that a macro might
+  // contain nested substitutions, e.g. argument expansions or nested
+  // expansions. Also, we should match statements which were expanded from
+  // macros containing a trailing semicolon.
+
+  // Algorithm:
+  // 1. Walk the first token's derived token chain from final expansion token to
+  //    the initial macro use token.
+  // 2. Walk up this token's expansion tree. If we encounter a non-substitution
+  //    macro, stop traversing the expansion tree and ascend the derivation
+  //    tree. If we encounter a macro substitution, check that this token is the
+  //    first in the macro's replacement list. If so, the continue to the next
+  //    step; otherwise keep ascending the token derivation tree. There is also
+  //    an edge-case to check for: If the current token is the first token in
+  //    the macro's intermediate expansion children, then we must immediately
+  //    return early, because otherwise we might erroneously match a macro with
+  //    one of its arguments if they share a derivation tree. For example:
+  //      #define ADD(X, Y)
+  //      int x = ADD(ADD(1, 2), 3)
+  //    This check prevents 1 + 2 + 3 from aligning with both invocations of
+  //    ADD(), and ensures that it will only align with the top-level
+  //    invocation.
+  // 3. Walk up the last token's derived token chain from the initial macro use
+  //    token to the final macro expansion token.
+  // 4. Walk up the last derived token's derivation tree. If the last token is
+  //    ever derived from the same token that the first token is derived from,
+  //    then exit this iteration early to avoid false positives. If we encounter
+  //    a macro substitution, check that this token is the last in the macro's
+  //    replacement list. Follow similar logic as when checking for
+  //    front-alignment. This also where we incorporate the heuristic for
+  //    aligning macros that contain semicolons. If this check succeeds, then we
+  //    have found an aligned invocation.
+  // 5. The algorithm ends once we have walked the first token's entire
+  //    derivation chain.
+  auto b_tok = Front(), e_tok = Back();
+
   std::vector<MacroSubstitution> result;
-  if (!maybe_front) {
+  if (!b_tok || !*b_tok || !e_tok || !*e_tok) {
     return result;
   }
 
-  Token front = std::move(maybe_front.value());
-  Token back = Back().value();
+  auto b_tok_deriv_chain = b_tok->MacroDerivationChain();
 
-  auto maybe_front_macro = front.MacroLocation();
-  auto maybe_back_macro = front.MacroLocation();
-  if (!maybe_front_macro || !maybe_back_macro) {
-    return result;
+  auto e_tok_deriv_chain = e_tok->MacroDerivationChain();
+
+  // If the heuristic is enabled, keep track of the token that immediately
+  // follows this range to check if it's a semicolon.
+  auto tok_after_e_tok = heuristic ? e_tok->NextMacroToken() : std::nullopt;
+  bool semi =
+      tok_after_e_tok && tok_after_e_tok->TokenKind() == TokenKind::kSemi;
+
+  for (auto b_deriv : b_tok_deriv_chain) {
+    std::optional<Macro> b_macro = b_deriv;
+    if (!b_macro) {
+      continue;
+    }
+
+    for (auto b_parent = b_macro->Parent(); b_parent;
+         b_macro = *b_parent, b_parent = b_parent->Parent()) {
+      auto b_parent_sub = MacroSubstitution::From(*b_parent);
+      if (!b_parent_sub) {
+        break;
+      }
+
+      // Here is the first edge-case. We only allow a macro token to be the
+      // first child in its parent's intermediate replacement list if the macro
+      // token is a parameter substitution.
+      if (auto b_parent_exp = MacroExpansion::From(*b_parent_sub)) {
+        MacroRange body = b_parent_exp->IntermediateChildren();
+        bool is_psub = b_macro->Kind() == MacroKind::kParameterSubstitution;
+        if (b_macro == body.Front() && !is_psub) {
+          return result;
+        }
+      }
+
+      auto b_parent_replacement = b_parent_sub->ReplacementChildren();
+      bool front_aligned = (b_macro == b_parent_replacement.Front());
+      if (!front_aligned) {
+        break;
+      }
+
+      for (auto e_deriv : e_tok_deriv_chain) {
+        // Here's the rub: If the begin and end tokens ever converge to the same
+        // derived token, then their derivation trees have started mixing. This
+        // can happen if two separate arguments of the macro are invocations of
+        // the same macro definition. To see an example, print the macro graph
+        // of the following invocation code snippet:
+        //
+        // #define ONE 1
+        // #define ADD(x, y) x + y
+        // ADD(ONE, ONE)
+        //
+        // This isn't a problem if the begin and end tokens were the same tokens
+        // to begin with (then of course their derivation trees would be the
+        // same). Otherwise we should exit early, since this mixing might cause
+        // us to return a false positive.
+
+        // NOTE(bpappas): I am fairly certain that returning here will prevent
+        // false positives, but I am not sure if it will create false negatives.
+        if (b_deriv == e_deriv && b_tok != e_tok) {
+          break;
+        }
+
+        std::optional<Macro> e_macro = e_deriv;
+        if (!e_macro) {
+          continue;
+        }
+
+        for (auto e_parent = e_macro->Parent(); e_parent;
+             e_macro = *e_parent, e_parent = e_parent->Parent()) {
+          auto e_parent_sub = MacroSubstitution::From(*e_parent);
+          if (!e_parent_sub) {
+            break;
+          }
+
+          if (auto e_parent_exp = MacroExpansion::From(*e_parent_sub)) {
+            MacroRange body = e_parent_exp->IntermediateChildren();
+            bool is_psub = e_macro->Kind() == MacroKind::kParameterSubstitution;
+            if (e_macro == body.Back() && !is_psub) {
+              break;
+            }
+          }
+
+          auto psub_last_mtok = e_parent_sub->LastFullySubstitutedToken();
+          auto e_parent_replacement = e_parent_sub->ReplacementChildren();
+          bool back_aligned = ((e_macro == e_parent_replacement.Back()) ||
+                               (semi && tok_after_e_tok == psub_last_mtok));
+
+          if (!back_aligned) {
+            break;
+          }
+
+          if (b_parent == e_parent) {
+            result.push_back(*b_parent_sub);
+          }
+        }
+      }
+    }
   }
-
-  MacroToken fm = std::move(maybe_front_macro.value());
-  MacroToken bm = std::move(maybe_back_macro.value());
-
-  (void) fm;
-  (void) bm;
 
   return result;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,6 @@ configure_lit_site_cfg(
 )
 
 set(PASTA_TEST_DEPENDS
-  print-tokens
   print-aligned-substitutions
 )
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -49,18 +49,6 @@ config.pasta_tools_dir = os.path.join(config.pasta_obj_root, 'bin')
 
 tools = [
     ToolSubst(
-        "print-cxx-tokens",
-        os.path.join(config.pasta_obj_root, 'bin',
-                     'PrintTokens','print-tokens'),
-        extra_args=["-x", "c++"]),
-
-    ToolSubst(
-        "print-c-tokens",
-        os.path.join(config.pasta_obj_root, 'bin',
-                     'PrintTokens', 'print-tokens'),
-        extra_args=["-x", "c"]),
-
-    ToolSubst(
         "print-aligned-substitutions",
         os.path.join(config.pasta_obj_root, 'bin',
                      'PrintAlignedSubstitutions',


### PR DESCRIPTION
- Redefines token methods for finding substitutions that align with token ranges
- Removed the previously deleted print-tokens target from test suite files
- Changes the `AlignedParameterSubstitutions()` method to return a vec so that the order of results is consistent with the order of a macro's parameters.